### PR TITLE
[FEAT] 챗봇 음성 ver. - 음성 응답 중 마이크 버튼 잠금 처리 및 디바운싱 로직 분리

### DIFF
--- a/src/app/chat/VoicePage.tsx
+++ b/src/app/chat/VoicePage.tsx
@@ -1,10 +1,7 @@
 import CharacterScene from "@/components/chat/CharacterScene";
 import VoiceFooter from "@/components/chat/VoiceFooter";
-import { useState } from "react";
 
 export default function VoicePage() {
-  const [input, setInput] = useState("");
-
   return (
     <div className="flex h-full flex-col items-center justify-between">
       <CharacterScene />

--- a/src/components/chat/CharacterScene.tsx
+++ b/src/components/chat/CharacterScene.tsx
@@ -6,9 +6,11 @@ import { OrbitControls } from "@react-three/drei";
 import CharacterModel from "./CharacterModel";
 import ShadowRing from "./ShadowRing";
 import { useChatStore } from "@/store/useChatStore";
+import { useTTSStore } from "@/store/useTTSStore";
 
 export default function CharacterScene() {
-  const { speak, isSpeaking } = useTTS("Google 한국의 여성");
+  const { speak } = useTTS("Google 한국의 여성");
+  const isSpeaking = useTTSStore((state) => state.isSpeaking);
   const getLastBotMessage = useChatStore((state) => state.getLastBotMessage);
 
   const handleSpeak = () => {

--- a/src/components/chat/CharacterScene.tsx
+++ b/src/components/chat/CharacterScene.tsx
@@ -7,12 +7,18 @@ import CharacterModel from "./CharacterModel";
 import ShadowRing from "./ShadowRing";
 import { useChatStore } from "@/store/useChatStore";
 import { useTTSStore } from "@/store/useTTSStore";
+import { useEffect, useRef } from "react";
 
 export default function CharacterScene() {
   const { speak } = useTTS("Google 한국의 여성");
   const isSpeaking = useTTSStore((state) => state.isSpeaking);
+
+  const messages = useChatStore((state) => state.messages);
   const getLastBotMessage = useChatStore((state) => state.getLastBotMessage);
 
+  const prevBotMessageRef = useRef<string | null>(null);
+
+  // 모델 클릭 시 수동 발화
   const handleSpeak = () => {
     const lastBotMessage = getLastBotMessage();
     if (lastBotMessage) {
@@ -21,6 +27,18 @@ export default function CharacterScene() {
       speak("지금은 대화가 준비되지 않았어요.");
     }
   };
+
+  // messages 변경 감지하여 자동 발화
+  useEffect(() => {
+    const latestBotMsg = [...messages].reverse().find((m) => m.role === "bot");
+    if (!latestBotMsg) return;
+
+    // 중복 방지: 이미 읽은 메시지면 무시
+    if (latestBotMsg.content !== prevBotMessageRef.current) {
+      prevBotMessageRef.current = latestBotMsg.content;
+      speak(latestBotMsg.content);
+    }
+  }, [messages]);
 
   return (
     <div className="relative flex h-[80%] w-full items-center justify-center">

--- a/src/components/chat/VoiceFooter.tsx
+++ b/src/components/chat/VoiceFooter.tsx
@@ -4,19 +4,25 @@ import { Mic } from "lucide-react";
 import { useVoiceRecorder } from "@/hooks/useVoiceRecorder";
 import ShadowRing from "./ShadowRing";
 import { useHandleAnswer } from "@/hooks/useHandleAnswer";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTTSStore } from "@/store/useTTSStore";
 import { Button } from "../ui/button";
+import { useBotResponseGuard } from "@/hooks/useBotResponseGuard";
+import { useVoiceControlStore } from "@/store/useVoiceControlStore";
 
 export default function VoiceFooter() {
   const { recording, result, toggleRecording } = useVoiceRecorder();
   const { handleNormalizedAnswer } = useHandleAnswer();
+  const { setWaitingForBotResponse } = useVoiceControlStore();
   const isSpeaking = useTTSStore((state) => state.isSpeaking);
+  const [waitingTrigger, setWaitingTrigger] = useState(false);
+  useBotResponseGuard(waitingTrigger);
 
   // 음성 인식 결과가 나올 때 자동으로 handleAnswer 실행
   useEffect(() => {
     if (result) {
-      console.log(result);
+      setWaitingTrigger(true);
+      setWaitingForBotResponse(true); // 마이크 잠금 시작
       handleNormalizedAnswer(result);
     }
   }, [result]);

--- a/src/components/chat/VoiceFooter.tsx
+++ b/src/components/chat/VoiceFooter.tsx
@@ -5,10 +5,13 @@ import { useVoiceRecorder } from "@/hooks/useVoiceRecorder";
 import ShadowRing from "./ShadowRing";
 import { useHandleAnswer } from "@/hooks/useHandleAnswer";
 import { useEffect } from "react";
+import { useTTSStore } from "@/store/useTTSStore";
+import { Button } from "../ui/button";
 
 export default function VoiceFooter() {
   const { recording, result, toggleRecording } = useVoiceRecorder();
   const { handleNormalizedAnswer } = useHandleAnswer();
+  const isSpeaking = useTTSStore((state) => state.isSpeaking);
 
   // 음성 인식 결과가 나올 때 자동으로 handleAnswer 실행
   useEffect(() => {
@@ -30,14 +33,15 @@ export default function VoiceFooter() {
       />
 
       {/*  마이크 버튼 */}
-      <button
+      <Button
         onClick={toggleRecording}
+        disabled={isSpeaking}
         className="z-10 flex h-16 w-16 items-center justify-center rounded-full bg-yellow-100 shadow-md">
         <Mic
-          size={28}
+          size={30}
           className={`text-gray-700 ${recording ? "animate-ping" : ""}`}
         />
-      </button>
+      </Button>
 
       {/*  인식된 텍스트 출력 */}
       {result && (

--- a/src/hooks/useBotResponseGuard.ts
+++ b/src/hooks/useBotResponseGuard.ts
@@ -1,0 +1,20 @@
+// hooks/useBotResponseGuard.ts
+import { useEffect, useRef } from "react";
+import { useChatStore } from "@/store/useChatStore";
+import { useVoiceControlStore } from "@/store/useVoiceControlStore";
+
+export function useBotResponseGuard(trigger: boolean) {
+  const messages = useChatStore((state) => state.messages);
+  const { setWaitingForBotResponse } = useVoiceControlStore();
+  const prevBotContent = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!trigger) return;
+
+    const latestBot = [...messages].reverse().find((m) => m.role === "bot");
+    if (latestBot?.content !== prevBotContent.current) {
+      prevBotContent.current = latestBot?.content || null;
+      setWaitingForBotResponse(false); // 응답 도착 → 마이크 잠금 해제
+    }
+  }, [messages, trigger]);
+}

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,8 +1,9 @@
+import { useTTSStore } from "@/store/useTTSStore";
 import { useEffect, useState } from "react";
 
 export function useTTS(voiceName = "Google 한국의 여성") {
   const [voice, setVoice] = useState<SpeechSynthesisVoice | null>(null);
-  const [isSpeaking, setIsSpeaking] = useState(false);
+  const { setIsSpeaking } = useTTSStore();
 
   useEffect(() => {
     const loadVoices = () => {
@@ -39,5 +40,5 @@ export function useTTS(voiceName = "Google 한국의 여성") {
     speechSynthesis.speak(utter);
   };
 
-  return { speak, voice, isSpeaking };
+  return { speak, voice };
 }

--- a/src/store/useTTSStore.ts
+++ b/src/store/useTTSStore.ts
@@ -1,0 +1,12 @@
+// store/useTTSStore.ts
+import { create } from "zustand";
+
+interface TTSState {
+  isSpeaking: boolean;
+  setIsSpeaking: (value: boolean) => void;
+}
+
+export const useTTSStore = create<TTSState>((set) => ({
+  isSpeaking: false,
+  setIsSpeaking: (value) => set({ isSpeaking: value }),
+}));

--- a/src/store/useVoiceControlStore.ts
+++ b/src/store/useVoiceControlStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface VoiceControlState {
+  waitingForBotResponse: boolean;
+  setWaitingForBotResponse: (value: boolean) => void;
+}
+
+export const useVoiceControlStore = create<VoiceControlState>((set) => ({
+  waitingForBotResponse: false,
+  setWaitingForBotResponse: (value) => set({ waitingForBotResponse: value }),
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈
closes #65 

## 📝작업 내용
- 사용자 음성 입력 후 챗봇 응답(bot message)이 도착하기 전까지 마이크 버튼 비활성화 처리
- 음성 입력 → 응답 대기 → 응답 완료 시 마이크 잠금/해제 상태 전역 관리
- useHandleAnswer, VoiceFooter, 상태 관리 로직 간 관심사 분리 적용

1. useVoiceControlStore.ts (Zustand store)
- isMicLocked: 전역 마이크 잠금 상태
- lockMic(), unlockMic(): 외부에서 상태 제어

2. useBotResponseGuard.ts (훅)
- trigger === true 상태일 때 messages를 감시
- 새로운 bot 메시지가 도착하면 잠금 해제 처리

3. VoiceFooter.tsx 수정
- result가 나올 경우:
  - lockMic() 호출
  - setWatchBotResponse(true)로 디바운스 감시 시작
  - 버튼 비활성화 조건: isSpeaking || isMicLocked

