### PR TITLE
 [FEAT] 챗봇 음성 버전 말풍선 스트리밍 처리 및 텍스트 버전 UX 수정

### DIFF
--- a/src/components/chat/CharacterScene.tsx
+++ b/src/components/chat/CharacterScene.tsx
@@ -7,7 +7,7 @@ import CharacterModel from "./CharacterModel";
 import ShadowRing from "./ShadowRing";
 import { useChatStore } from "@/store/useChatStore";
 import { useTTSStore } from "@/store/useTTSStore";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import SpeechBubble from "./SpeechBubble";
 
 export default function CharacterScene() {
@@ -23,14 +23,29 @@ export default function CharacterScene() {
   const lastMessage = messages[messages.length - 1];
   const isWaitingForBot = lastMessage?.role === "user" && !isSpeaking;
 
+  const [streamingText, setStreamingText] = useState("");
+  const typingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const startStreaming = (text: string) => {
+    if (typingIntervalRef.current) clearInterval(typingIntervalRef.current);
+    setStreamingText("");
+    let i = 0;
+    typingIntervalRef.current = setInterval(() => {
+      i++;
+      setStreamingText(text.slice(0, i));
+      if (i >= text.length) clearInterval(typingIntervalRef.current!);
+    }, 50);
+  };
+
   // 모델 클릭 시 수동 발화
   const handleSpeak = () => {
     const lastBotMessage = getLastBotMessage();
-    if (lastBotMessage) {
-      speak(lastBotMessage.content);
-    } else {
+    if (!lastBotMessage) {
       speak("지금은 대화가 준비되지 않았어요.");
+      return;
     }
+    startStreaming(lastBotMessage.content);
+    speak(lastBotMessage.content);
   };
 
   // messages 변경 감지하여 자동 발화
@@ -41,6 +56,7 @@ export default function CharacterScene() {
     // 중복 방지: 이미 읽은 메시지면 무시
     if (latestBotMsg.content !== prevBotMessageRef.current) {
       prevBotMessageRef.current = latestBotMsg.content;
+      startStreaming(latestBotMsg.content);
       speak(latestBotMsg.content);
     }
   }, [messages]);
@@ -49,7 +65,7 @@ export default function CharacterScene() {
     <div className="relative flex h-[80%] w-full items-center justify-center">
       {/* 💬 말풍선 표시 */}
       {isSpeaking && latestBotMsg?.content && (
-        <SpeechBubble text={latestBotMsg.content} />
+        <SpeechBubble text={streamingText} />
       )}
       <Canvas
         style={{ width: "60%", height: "50%" }}


### PR DESCRIPTION
## #️⃣연관된 이슈

#93 

## 📝작업 내용

- 챗봇 음성 버전 말풍선 스트리밍 처리를 위해 `CharacterScene.tsx` 내에 `startStreaming` 메소드 생성하여 message 변경시와 모델 클릭시 스트리밍 처리
- 챗봇 텍스트 버전 width `estimatedWidth` 계산하여 고정되게 설정

## 스크린샷 (선택)
- 챗봇 음성 버전 말풍선 스트리밍

![화면 기록 2025-06-13 오후 2 35 36](https://github.com/user-attachments/assets/d7bc7674-af89-4180-b505-4b353c5256a6)

- 챗봇 텍스트 버전 스트리밍 width 고정

![화면 기록 2025-06-13 오후 2 37 22](https://github.com/user-attachments/assets/312fc243-54fb-4d20-a2f0-ae7995476f85)

## 💬리뷰 요구사항(선택)

기능 구현에 집중해서 코드 리팩토링 관련 피드백 있다면 달아주세요