### PR TITLE
[BUG] 상세페이지 혜택 카드 유무에 따른 ui 깨짐 버그 해결

### DIFF
--- a/src/app/plandetail/[id]/page.tsx
+++ b/src/app/plandetail/[id]/page.tsx
@@ -40,7 +40,7 @@ export default function PlanDetailPage() {
       <PlanDetailHeader />
       <main className="relative flex flex-col items-center space-y-8 overflow-hidden bg-gradient-to-b">
         <TopGradient />
-        <section className="relative z-10 max-w-md">
+        <section className="relative z-10 w-full space-y-[3rem]">
           <PlanInfo data={planData} mode={mode} onChangeMode={setMode} />
           <PlanCharts data={planData} mode={mode} />
           <PlanBenefits benefits={planData.benefits} />

--- a/src/components/planDetail/PlanBenefits.tsx
+++ b/src/components/planDetail/PlanBenefits.tsx
@@ -20,7 +20,7 @@ export default function PlanBenefits({ benefits }: PlanBenefitsProps) {
   });
 
   return (
-    <div className="relative mt-15">
+    <div className="relative mt-15 min-h-65">
       <div ref={sliderRef} className="keen-slider px-4 py-2">
         {benefits.map((item, index) => (
           <div key={index} className="keen-slider__slide">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #101 

## 📝작업 내용

1. 하단 그라디언트 위치 수정
> BottomGradient 컴포넌트 위치를 조정
콘텐츠 높이에 따라 위치가 밀리는 현상 제거 → 일정한 하단 영역 유지

2. [main bug] page에서 max-w-md 제거로 width 불일치 해결
> LayoutWrapper에서 이미 상위 width를 아래처럼 고정: max-w-[430px]
그런데 내부 PlanDetailPage에서 또다시: max-w-md  →  max-w-[448px]를 지정하여, 부모보다 자식이 커지는 구조가 됨....

> 그래서 혜택 카드가 없는 공간이 밀려서 미세하게 UI 깨지는? 문제 발생
해당 불필요한 max-w-md 제거 → w-full로 일괄 고정하여 상위 wrapper의 width와 항상 일관성 유지

> 결과적으로 요금제명 길이 차이, 혜택 카드 유무와 관계없이 항상 동일한 UI를 유지합니다.

### 스크린샷 (선택)

- 기존 문제 (하단의 ott 카드가 없는 경우 상단의 ui가 미세하게 달라짐)
![문제2](https://github.com/user-attachments/assets/1e6d8286-2bf5-46d1-b574-27dae87999e3)

---

- 개선된 모습
![image](https://github.com/user-attachments/assets/fc67ac6b-e84b-46e4-9802-82efbf9eec5b)


## 💬리뷰 요구사항(선택)

> 혜택 카드가 없는 경우 발생하는 해당 버그와 하단 그레디언트 위치 수정 완료했습니다. 개선 사항 있으시면 말씀해주세요.