### PR TITLE
[FEAT] 챗봇 플로팅 버튼 및 타이핑 애니메이션 구현

### DIFF
--- a/src/components/common/FloatingChatbotButton.tsx
+++ b/src/components/common/FloatingChatbotButton.tsx
@@ -7,12 +7,12 @@ export default function FloatingChatbotButton() {
 
   return (
     <div
-      className="absolute right-6 bottom-6 z-50 flex flex-col items-center"
+      className="fixed bottom-4 left-1/2 z-50 flex translate-x-[calc(215px-100%)] flex-col items-center"
       onClick={() => router.push("/chatbot")}>
       <div className="mb-1 rounded-md bg-white px-3 py-1 text-sm shadow-md">
         무너에게 물어봐
       </div>
-      <div className="h-20 w-20">
+      <div className="h-16 w-16">
         <Canvas camera={{ position: [0, 0, 2.5] }}>
           <ambientLight intensity={0.7} />
           <CharacterModel

--- a/src/components/common/FloatingChatbotButton.tsx
+++ b/src/components/common/FloatingChatbotButton.tsx
@@ -1,17 +1,59 @@
 import CharacterModel from "../chat/CharacterModel";
 import { Canvas } from "@react-three/fiber";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 
 export default function FloatingChatbotButton() {
   const router = useRouter();
 
+  const fullText = "무너에게 물어봐";
+  const [visible, setVisible] = useState(true);
+  const [typed, setTyped] = useState("");
+
+  useEffect(() => {
+    let current = 0;
+
+    const typeNext = () => {
+      setTyped(fullText.slice(0, current + 1));
+      current++;
+
+      if (current < fullText.length) {
+        setTimeout(typeNext, 130);
+      } else {
+        setTimeout(() => setVisible(false), 1300);
+      }
+    };
+
+    // 문어 렌더링 이후 살짝 딜레이 후 등장
+    const delayStart = setTimeout(() => {
+      setVisible(true);
+      typeNext();
+    }, 300);
+
+    return () => {
+      clearTimeout(delayStart);
+    };
+  }, []);
+
   return (
     <div
       className="fixed bottom-1 left-1/2 z-50 flex translate-x-[calc(220px-100%)] flex-col items-center"
-      onClick={() => router.push("/chatbot")}>
-      <div className="mb-[-2rem] rounded-full bg-white px-4 py-1.5 text-sm font-medium whitespace-nowrap shadow-md">
-        무너에게 물어봐
-      </div>
+      onClick={() => router.push("/chat")}>
+      <AnimatePresence>
+        {visible && (
+          <motion.div
+            key="balloon"
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            transition={{ duration: 0.4 }}
+            className="mb-[-2rem] rounded-full bg-white px-4 py-1.5 text-sm font-medium whitespace-nowrap shadow-md">
+            {typed}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <div className="h-40 w-40">
         <Canvas camera={{ position: [0, 0, 2.5] }}>
           <ambientLight intensity={0.7} />

--- a/src/components/common/FloatingChatbotButton.tsx
+++ b/src/components/common/FloatingChatbotButton.tsx
@@ -7,14 +7,16 @@ export default function FloatingChatbotButton() {
 
   return (
     <div
-      className="fixed bottom-4 left-1/2 z-50 flex translate-x-[calc(215px-100%)] flex-col items-center"
+      className="fixed bottom-1 left-1/2 z-50 flex translate-x-[calc(220px-100%)] flex-col items-center"
       onClick={() => router.push("/chatbot")}>
-      <div className="mb-1 rounded-md bg-white px-3 py-1 text-sm shadow-md">
+      <div className="mb-[-2rem] rounded-full bg-white px-4 py-1.5 text-sm font-medium whitespace-nowrap shadow-md">
         무너에게 물어봐
       </div>
-      <div className="h-16 w-16">
+      <div className="h-40 w-40">
         <Canvas camera={{ position: [0, 0, 2.5] }}>
           <ambientLight intensity={0.7} />
+          <directionalLight position={[0, 0, 2]} intensity={0.6} />
+          <hemisphereLight intensity={0.6} groundColor="white" />
           <CharacterModel
             onClick={() => router.push("/chatbot")}
             isSpeaking={false}

--- a/src/components/common/FloatingChatbotButton.tsx
+++ b/src/components/common/FloatingChatbotButton.tsx
@@ -1,0 +1,27 @@
+import CharacterModel from "../chat/CharacterModel";
+import { Canvas } from "@react-three/fiber";
+import { useRouter } from "next/navigation";
+
+export default function FloatingChatbotButton() {
+  const router = useRouter();
+
+  return (
+    <div
+      className="absolute right-6 bottom-6 z-50 flex flex-col items-center"
+      onClick={() => router.push("/chatbot")}>
+      <div className="mb-1 rounded-md bg-white px-3 py-1 text-sm shadow-md">
+        무너에게 물어봐
+      </div>
+      <div className="h-20 w-20">
+        <Canvas camera={{ position: [0, 0, 2.5] }}>
+          <ambientLight intensity={0.7} />
+          <CharacterModel
+            onClick={() => router.push("/chatbot")}
+            isSpeaking={false}
+            isThinking={false}
+          />
+        </Canvas>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/LayoutWrapper.tsx
+++ b/src/components/common/LayoutWrapper.tsx
@@ -1,12 +1,27 @@
+// components/LayoutWrapper.tsx
+"use client";
+
+import { usePathname } from "next/navigation";
+import FloatingChatbotButton from "./FloatingChatbotButton";
+
 export default function LayoutWrapper({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const pathname = usePathname();
+
+  // 챗봇 버튼을 보여줄 경로 설정
+  const visiblePaths = ["/", "/plandetail"];
+  const shouldShowChatbot = visiblePaths.some((path) =>
+    pathname.startsWith(path)
+  );
+
   return (
     <div className="flex justify-center">
-      <div className="flex min-h-screen w-full max-w-[430px] flex-col bg-white">
+      <div className="relative flex min-h-screen w-full max-w-[430px] flex-col bg-white">
         {children}
+        {shouldShowChatbot && <FloatingChatbotButton />}
       </div>
     </div>
   );

--- a/src/components/common/LayoutWrapper.tsx
+++ b/src/components/common/LayoutWrapper.tsx
@@ -12,7 +12,7 @@ export default function LayoutWrapper({
   const pathname = usePathname();
 
   // 챗봇 버튼을 보여줄 경로 설정
-  const visiblePaths = ["/", "/plandetail"];
+  const visiblePaths = ["/plandetail"];
   const shouldShowChatbot = visiblePaths.some((path) =>
     pathname.startsWith(path)
   );


### PR DESCRIPTION
## #️⃣연관된 이슈
closes #112 

## 📝작업 내용
- 요금제 상세 페이지 등 일부 경로에서만 노출되는 챗봇 플로팅 버튼을 구현했습니다.
- 3D 캐릭터(무너)를 포함한 버튼으로, 클릭 시 /chat 페이지로 이동합니다.
- 첫 마운트 시 말풍선이 나타나고, "무너에게 물어봐"라는 문구가 타이핑 효과로 출력된 뒤, 일정 시간 후 사라집니다.
- 등장/퇴장 애니메이션은 Framer Motion을 사용하여 부드럽게 처리했습니다.
- LayoutWrapper에서 pathname에 따라 조건부 렌더링 처리합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
현재 타이핑 효과는 말풍선용으로 독립 구현되어 있습니다.
그런데 /chat 페이지에도 스트리밍 기반 문장 출력 기능이 이미 구현되어 있습니다.
두 기능이 유사한 흐름을 가지므로, useTypingEffect와 같은 공통 커스텀 훅으로 분리가 가능한지 리뷰 부탁드립니다. @alotofhee 
> 혹시 관련 부분을 함께 리팩토링해도 좋을지 의견 주시면 감사하겠습니다!
