### PR TITLE
[FIX] 음성 챗봇 발화 트리거 정책 대응 및 추천 카드 연동 개선

### DIFF
--- a/src/components/chat/CharacterScene.tsx
+++ b/src/components/chat/CharacterScene.tsx
@@ -9,6 +9,8 @@ import { useChatStore } from "@/store/useChatStore";
 import { useTTSStore } from "@/store/useTTSStore";
 import { useEffect, useRef, useState } from "react";
 import SpeechBubble from "./SpeechBubble";
+import PlanCard from "./PlanCard";
+import { AnimatePresence, motion } from "framer-motion";
 
 export default function CharacterScene() {
   const { speak } = useTTS();
@@ -53,7 +55,7 @@ export default function CharacterScene() {
     const latestBotMsg = getLastBotMessage();
     if (!latestBotMsg) return;
 
-    // 중복 방지: 이미 읽은 메시지면 무시
+    // 중복 방지
     if (latestBotMsg.content !== prevBotMessageRef.current) {
       prevBotMessageRef.current = latestBotMsg.content;
       startStreaming(latestBotMsg.content);
@@ -61,12 +63,33 @@ export default function CharacterScene() {
     }
   }, [messages]);
 
+  // PlanCard를 보여줄 조건: 마지막 메시지가 plan type
+  const shouldShowPlanCard =
+    lastMessage?.role === "bot" &&
+    lastMessage?.type === "plan" &&
+    lastMessage?.planData;
+
   return (
-    <div className="relative flex h-[80%] w-full items-center justify-center">
-      {/* 💬 말풍선 표시 */}
+    <div className="relative flex h-[80%] w-full flex-col items-center justify-center">
+      {/* 말풍선 표시 */}
       {isSpeaking && latestBotMsg?.content && (
         <SpeechBubble text={streamingText} />
       )}
+
+      {/* 최종 요금제 추천 카드 UI */}
+      <AnimatePresence>
+        {shouldShowPlanCard && (
+          <motion.div
+            key="plan-card"
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.7, ease: "easeOut" }}>
+            <PlanCard {...lastMessage.planData!} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+      {/* 3D 문어 */}
       <Canvas
         style={{ width: "60%", height: "50%" }}
         camera={{ position: [0, 2, 4], fov: 35 }}>
@@ -83,6 +106,7 @@ export default function CharacterScene() {
           enableRotate={false}
         />
       </Canvas>
+
       <ShadowRing
         isActive={isSpeaking}
         color="bg-pink-400"


### PR DESCRIPTION
## 📎 연관된 이슈
> closes #113

## ✍️ 작업 내용
- 브라우저 자동재생 제한(autoplay policy)을 회피하기 위해, **최초 사용자 클릭 이후에만 TTS 자동 발화**가 가능하도록 로직 수정
> Error: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD
- 사용자 상호작용이 없는 경우, 문어 모델 하단에 `"클릭해서 시작해보세요 👆"` 안내 문구 표시
- 음성 챗봇 페이지에서 **마지막 메시지가 plan 타입일 경우**, 해당 요금제 추천 카드(PlanCard)를 하단에 자연스럽게 표시
  - **Framer Motion**을 사용하여 등장 애니메이션 처리
- 기존 `TextPage`의 로직과 통일성을 맞추되, 음성 중심 흐름에 맞게 출력 구조 최적화

---

### 🎬 스크린샷 (선택)

- 최초 상태: 문어 아래 안내 문구 표시
- 클릭 후: 자동 발화 시작
- 추천 메시지 도달 시: PlanCard 등장
<img width="434" alt="image" src="https://github.com/user-attachments/assets/00edac86-2143-4e0b-b6a2-9ff2062354f9" />
<img width="427" alt="image" src="https://github.com/user-attachments/assets/23e21338-7fbf-4c31-93a2-bdad95a035ad" />


---

## 💬 리뷰 요청사항

- TTS 발화 조건 분기(`hasInteracted` 기준)가 깔끔하게 처리되었는지 확인 부탁드립니다.
- 추후 `speak()` 관련 로직을 공통 hook으로 분리할 필요가 있을지에 대한 의견도 요청드립니다.
