### PR TITLE
[FEAT] 챗봇 텍스트버전 width 고정되게 적용

### DIFF
--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -1,4 +1,4 @@
-import { Message } from "@/types/message";
+import { Message } from "@/types/Chat";
 import ChatMessage from "./ChatMessage";
 import { useChatStore } from "@/store/useChatStore";
 

--- a/src/components/chat/TypingMessage.tsx
+++ b/src/components/chat/TypingMessage.tsx
@@ -17,7 +17,6 @@ export default function TypingMessage({
 
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  // const estimatedWidth = Math.min(fullText.length * 8 + 24, 320);
   function measureTextWidth(text: string, font = "14px Pretendard") {
     const canvas = document.createElement("canvas");
     const ctx = canvas.getContext("2d");

--- a/src/components/chat/TypingMessage.tsx
+++ b/src/components/chat/TypingMessage.tsx
@@ -17,6 +17,16 @@ export default function TypingMessage({
 
   const bottomRef = useRef<HTMLDivElement>(null);
 
+  // const estimatedWidth = Math.min(fullText.length * 8 + 24, 320);
+  function measureTextWidth(text: string, font = "14px Pretendard") {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return 100;
+    ctx.font = font;
+    return ctx.measureText(text).width + 24; // padding 고려
+  }
+  const estimatedWidth = Math.min(measureTextWidth(fullText), 322.5);
+
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [displayedText]);
@@ -37,7 +47,9 @@ export default function TypingMessage({
 
   return (
     <>
-      <div className="max-w-[75%] rounded-tr-2xl rounded-br-2xl rounded-bl-2xl bg-white px-3 py-2 text-sm shadow-md">
+      <div
+        className="max-w-[75%] rounded-tr-2xl rounded-br-2xl rounded-bl-2xl bg-white px-3 py-2 text-sm shadow-md"
+        style={{ width: `${estimatedWidth}px` }}>
         {displayedText}
       </div>
       <div ref={bottomRef} />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93 

## 📝작업 내용

- `measureTextWidth` 함수로 전체 텍스트의 예상 픽셀 너비 측정하여 `TypingMessage.tsx` 컴포넌트에서 width style에 고정
- Tailwind의 max-w-[75%] 클래스가 style={{ width: ... }}와 함께 사용될 때 제대로 적용되지 않아, 스타일 충돌을 방지하기 위해 최대 너비를 322.5px로 고정
 
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
