### PR TITLE
#125 bug: 상세페이지 그래프 출력 오류 해결

### DIFF
--- a/src/app/api/plan/id/[id]/route.ts
+++ b/src/app/api/plan/id/[id]/route.ts
@@ -3,11 +3,12 @@ import { prisma } from "@/lib/prisma";
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const id = Number(params.id);
+  const { id } = await params; //핵심 수정 (15.3.3 대응)
+  const idNum = Number(id);
 
-  if (isNaN(id)) {
+  if (isNaN(idNum)) {
     return NextResponse.json(
       { error: "유효한 숫자 ID가 아닙니다." },
       { status: 400 }
@@ -15,7 +16,7 @@ export async function GET(
   }
 
   try {
-    const plan = await prisma.plan.findUnique({ where: { id } });
+    const plan = await prisma.plan.findUnique({ where: { id: idNum } });
 
     if (!plan) {
       return NextResponse.json(

--- a/src/utils/mapPlanToDetailData.ts
+++ b/src/utils/mapPlanToDetailData.ts
@@ -26,50 +26,40 @@ function getBenefits(services: string[]): PlanDetailData["benefits"] {
     .map((s) => serviceMap[s])
     .filter((b): b is PlanDetailData["benefits"][number] => b !== undefined);
 }
+
 function normalize(value: number, min: number, max: number) {
   if (max === min) return 50;
-  return Math.round(((value - min) / (max - min)) * 100);
+  const clamped = Math.min(Math.max(value, min), max);
+  return Math.round(((clamped - min) / (max - min)) * 100);
 }
 
 export function mapPlanToDetailData(
   plan: PlanDBApiResponse,
   context: ScoreContext
 ): PlanDetailData {
+  const priceScore = 100 - normalize(plan.price, 10000, 105000);
   const dataScore = normalize(
-    plan.dataAmountMb ?? 0,
-    context.minData,
-    context.maxData
+    (plan.dataAmountMb ?? 0) > 999999 ? 300000 : (plan.dataAmountMb ?? 0),
+    0,
+    300000
   );
+  const speedScore = normalize(plan.overageSpeedMbps ?? 0, 0, 5);
   const voiceScore = normalize(
     plan.voiceMinutes < 0 ? 9999 : (plan.voiceMinutes ?? 0),
-    context.minVoice,
-    context.maxVoice
+    0,
+    400
   );
-  const priceScore =
-    100 - normalize(plan.price, context.minPrice, context.maxPrice); // 낮을수록 좋음
-  const speedScore = normalize(
-    plan.overageSpeedMbps ?? 0,
-    context.minSpeed,
-    context.maxSpeed
-  );
-
   const smsScore = plan.smsIncluded ? 100 : 0;
+
+  const scoreArray = [priceScore, dataScore, speedScore, voiceScore, smsScore];
 
   return {
     name: plan.name,
     price: `월 ${plan.price.toLocaleString()} 원`,
-    tags: ["정제된 태그", "LTE", "혜택 풍부"],
-
-    radar: [priceScore, dataScore, speedScore, voiceScore, smsScore],
-    bar: [
-      plan.price,
-      plan.dataAmountMb ?? 0,
-      plan.overageSpeedMbps ?? 0,
-      plan.voiceMinutes < 0 ? 9999 : plan.voiceMinutes,
-      plan.smsIncluded ? 1 : 0,
-    ],
+    tags: ["정제된 태그", plan.networkType, "혜택 풍부"],
+    radar: scoreArray,
+    bar: scoreArray,
     compare: [40, 82, 84, 43, 59],
-
     benefits: getBenefits(plan.subscriptionServices),
   };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #125 

## 📝작업 내용

1. params 비동기 접근 수정 (Next.js 15.3.3 대응)

- 수정 파일: src/app/api/plan/id/[id]/route.ts

>Next.js 공식문서 확인 후 비동기 params 구조에 맞게 수정
{ params }: { params: Promise<{ id: string }> } 로 타입 변경
내부에서 const { id } = await params로 정상 추출하도록 수정

- 결론: Next.js 15.3.3 이상 버전에서 발생하는 params.id 접근 오류 해결

2. 요금제 입력 값 계산 로직 개선

- 수정 파일: src/utils/mapPlanToDetailData.ts

- 데이터 스케일링 구간 재조정 → 구간에 따른 그래프의 시각적 출력 향상
> price: 10000 ~ 105000
> dataAmountMb: 0 ~ 300000 (상한제 적용)
> speed: 0 ~ 5
> voice: 0 ~ 400
> sms: 0 또는 1 → 100점 or 0점

- 결론: 기존 999999Mb 등 비정상 데이터 상한처리 (999999 이상은 300000으로 보정)

### 스크린샷 (선택)

- 기존 이미지: 각각의 범위 차이가 너무 커서 그래프가 시각적으로 역할을 못하는 상황
![image](https://github.com/user-attachments/assets/a131cf1c-adbb-490b-b2eb-f3d2d5133f25)

- 현재 이미지: 각각의 범위를 재설정하여 시각적으로 차이를 나타내는 상황
![image](https://github.com/user-attachments/assets/5a335d3e-a6f7-47c3-9410-43c5b0f3448b)


## 💬리뷰 요구사항(선택)

> 기존에 parmas 관련 오류를 먼저 해결했고, 이후 그래프가 제대로 ui로 확인하지 못하던 문제를 해결했습니다.
다만, 데이터 자체가 문자에서는 0 or 1뿐이라서 그래프가 이쁘지는 않습니다..
그래서 데이터의 차이가 크게 없는 입력 값들은 차라리 범위를 더 늘려서 표현하면 어떨지 의견 주시면 감사하겠습니다! (최저 값을 0으로 처리하면 그래프에는 시각적으로 아무것도 안 보이기에 해당 데이터가 있기는 하다?를 보여주고 싶습니다. 그런데 이렇게 처리하면 0인데 그래프가 당연히 출력이 안 되는게 맞다는 생각도 듭니다..)
ex) 속도 0 (null)~5까지 있는데, 범위 자체를 -1 ~ 5까지 설정..

> 바 그래프 툴팁 내용을 %로 바꿔봤는데, 아닌 것 같아서 원래대로 입력 값 자체가 출력되도록 수정해놓겠습니다.

## 추가 작업

- [ ] 곧바로 그래프 범위 조금 더 수정해서 데이터 전체 잘 출력되는지 확인
- [ ] DB 비교해서 이상 없는 지 확인
- [ ] DB에 ott 추가 (LG U+ 홈페이지와 동일하게 작업)

## 참고 자료

- parmas 오류 관련 공식 문서
https://nextjs.org/docs/messages/sync-dynamic-apis
