### PR TITLE
[REFACTOR] 차트 기능 개선

### DIFF
--- a/src/components/chart/options/barChartOptions.ts
+++ b/src/components/chart/options/barChartOptions.ts
@@ -44,8 +44,32 @@ export const barChartOptions: ChartOptions<"bar"> = {
       callbacks: {
         label: (context: TooltipItem<"bar">) => {
           const label = context.dataset.label || "";
-          const value = context.parsed.x;
-          return `${label}: ${value}%`;
+          const value = context.raw as number;
+          const index = context.dataIndex;
+
+          let displayValue = "";
+
+          switch (index) {
+            case 0:
+              displayValue = `월 ${value} 원`;
+              break;
+            case 1:
+              displayValue = `월 ${value} MB`;
+              break;
+            case 2:
+              displayValue = `다 쓰면 ${value} Mbps`;
+              break;
+            case 3:
+              displayValue = `부가통화 ${value} 분`;
+              break;
+            case 4:
+              displayValue = value === 100 ? "기본제공 O" : "기본제공 X";
+              break;
+            default:
+              displayValue = `${value}`;
+          }
+
+          return `${label}: ${displayValue}`;
         },
       },
     },

--- a/src/utils/mapPlanToDetailData.ts
+++ b/src/utils/mapPlanToDetailData.ts
@@ -40,7 +40,7 @@ export function mapPlanToDetailData(
   const priceScore = 100 - normalize(plan.price, 10000, 105000);
   const dataScore = normalize(
     (plan.dataAmountMb ?? 0) > 999999 ? 300000 : (plan.dataAmountMb ?? 0),
-    0,
+    -100000,
     300000
   );
   const speedScore = normalize(plan.overageSpeedMbps ?? 0, 0, 5);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #133 

## 📝작업 내용

> 차트 범위 재설정해서 시각적 기능을 향상시키려 했습니다만.. 의견이 필요하고 근본적으로 DB의 데이터를 먼저 개선해봐야 할 것 같다고 생각했습니다.

> 바 차트 툴팁에서 제공하는 정보를 커스텀해서 각각 단위와 내용에 부합하게 수정했지만, DB에서 받는 원본 데이터를 출력하려니 데이터를 정제하지 말아야하는 문제에 빠져서 조금 더 해결해봐야겠습니다.

> DB ott 추가 (LG u+ 홈페이지와 동일..+ ott 혜택 수량이 적어서 이것 또한 의견을 나눠봐야 할 것 같습니다.)

> DB 이상 확인 (스마트초이스를 기반으로 가야하기에 LG U+ 홈페이지의 요금제와 많이 다르다는 것만 전부 파악하기만 했고 수정은 안 했습니다.)

### 스크린샷 (선택)

- 월 데이터 최소 범위 0인 경우
![image](https://github.com/user-attachments/assets/b8925469-a975-4ff1-a48a-25198b0f215e)

- 월 데이터 최소 범위 -100,000인 경우
![image](https://github.com/user-attachments/assets/ed28f02b-08f6-43a2-927a-ba78c91abb5b)

## 💬리뷰 요구사항

- 해당 내용들은 의견 수렴해서 추가로 작업할 예정입니다.
- 레이더 차트에 각 영역별로 수치를 추가하려 합니다. (레이더 차트에도 툴팁 달면 지저분해 보일 것 같아서 이 작업은 제외하려 합니다.)