### PR TITLE
[FIX] 챗봇 입력창 마이크 버튼 클릭 시 음성 모드 전환 & 요금제 카드 클릭 시 상세 페이지 이동 기능 추가

### DIFF
--- a/src/components/chat/ChatInputBox.tsx
+++ b/src/components/chat/ChatInputBox.tsx
@@ -1,5 +1,6 @@
 import { ArrowUp, Mic } from "lucide-react";
 import { useRef } from "react";
+import { useRouter } from "next/navigation";
 
 interface ChatInputBoxProps {
   input: string;
@@ -16,6 +17,12 @@ export default function ChatInputBox({
 }: ChatInputBoxProps) {
   const formRef = useRef<HTMLFormElement>(null); // 엔터키 중복 방지를 위한 ref
   const isSubmittingRef = useRef(false);
+
+  const router = useRouter();
+
+  const handleMicClick = () => {
+    router.push("?mode=voice");
+  };
 
   return (
     <form
@@ -39,7 +46,10 @@ export default function ChatInputBox({
         className="w-full resize-none bg-[#FFEBAF] text-sm placeholder-[#94A3B8] focus:outline-none"
       />
       <div className="mt-2 flex justify-end gap-3">
-        <button type="button" className="text-[#94A3B8]">
+        <button
+          type="button"
+          className="text-[#94A3B8]"
+          onClick={handleMicClick}>
           <Mic size={20} />
         </button>
         <button type="submit" className="text-[#94A3B8]">

--- a/src/components/chat/PlanCard.tsx
+++ b/src/components/chat/PlanCard.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/card";
 import { ParsedPlanWithID } from "@/types/Chat";
 import { Badge } from "../ui/badge";
+import { useRouter } from "next/navigation";
 
 export default function PlanCard({
   id,
@@ -17,8 +18,15 @@ export default function PlanCard({
   price,
   tel,
 }: ParsedPlanWithID) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(`/plandetail/${id}`);
+  };
   return (
-    <Card className="w-full max-w-xs border-0 shadow-lg">
+    <Card
+      className="w-full max-w-xs cursor-pointer border-0 shadow-lg"
+      onClick={handleClick}>
       <CardHeader className="relative flex items-start justify-between px-4 pb-2">
         <span className="text-sm text-gray-800">LG U+</span>
         <CardAction className="text-sm font-semibold text-pink-600">


### PR DESCRIPTION
## #️⃣연관된 이슈
close #140 

## 📝작업 내용
- 텍스트 모드 챗봇 입력창 하단의 마이크 버튼 클릭 시 ?mode=voice로 이동하여 음성 모드로 전환되도록 구현
  - useRouter 사용하여 router.push('?mode=voice')로 처리
- 기존 음성/텍스트 모드 조건부 분기 유지 (mode === 'text' ? <TextPage /> : <VoicePage />)
  - PlanCard 클릭 시 /plandetail/{id}로 이동되도록 구현
- 카드 전체에 onClick 이벤트 등록
  - cursor-pointer 등 시각적 피드백 추가로 UX 향상
