### PR TITLE
#136 fix: 카카오 redirect 경로 수정

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 
 export default function LoginPage() {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") ?? "/";
+
   const handleLogin = () => {
-    const currentUrl = window.location.search.includes("callbackUrl=")
-      ? decodeURIComponent(
-          new URLSearchParams(window.location.search).get("callbackUrl")!
-        )
-      : "/";
-    signIn("kakao", { callbackUrl: currentUrl });
+    signIn("kakao", { callbackUrl });
   };
 
   return (

--- a/src/app/meme-test/[id]/page.tsx
+++ b/src/app/meme-test/[id]/page.tsx
@@ -99,7 +99,7 @@ export default function TestQuestionPage() {
 
     if (currentIndex === questions.length - 1) {
       if (!session?.user?.id) {
-        const callbackUrl = encodeURIComponent(window.location.href);
+        const callbackUrl = encodeURIComponent(window.location.pathname);
         router.push(`login?callbackUrl=${callbackUrl}`);
         return;
       }

--- a/src/app/meme-test/page.tsx
+++ b/src/app/meme-test/page.tsx
@@ -2,7 +2,6 @@
 
 import ShareSection from "@/components/meme/shareSection";
 import { useGetTypeRankQuery } from "@/hooks/useGetTypeRankQuery";
-import { useUpdateTestedCount } from "@/hooks/useUpdateTestedCount";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
@@ -18,11 +17,15 @@ export default function TestHomePage() {
   const topMoonos = (data?.moonos ?? [])
     .sort((a, b) => b.percent - a.percent)
     .slice(0, 2);
-  console.log("Top Moonos:", topMoonos);
 
   const handleStart = () => {
     const randomId = Math.random().toString(36).substring(2, 10);
-    router.push(`/meme-test/${randomId}`);
+    if (!session) {
+      const callbackUrl = `/meme-test/${randomId}`;
+      router.push(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+    } else {
+      router.push(`/meme-test/${randomId}`);
+    }
   };
 
   return (
@@ -55,14 +58,12 @@ export default function TestHomePage() {
 
         <hr className="my-3 w-[90%] border border-pink-400" />
 
-        {session?.user?.id && (
-          <ShareSection
-            title="테스트 공유하기"
-            count={data.sharedCount}
-            id={session.user.id}
-            shareUrl="/meme-test"
-          />
-        )}
+        <ShareSection
+          title="테스트 공유하기"
+          count={data.sharedCount ?? 0}
+          id={session?.user.id ?? 0}
+          shareUrl="/meme-test"
+        />
 
         <div className="mb-8 flex w-[90%] flex-col gap-4 rounded-lg border-1 border-pink-400 bg-white p-4 shadow-md">
           {topMoonos.map((moono, index) => (


### PR DESCRIPTION
## #️⃣연관된 이슈
#136 

## 📝작업 내용
- 카카오 로그인 Redirect URI 문제 해결 및 밈테스트 로그인 리디렉션 흐름 구
- `callbackUrl` 중첩 문제 수정
- 로그인 후 밈테스트 랜딩 유지
- 카카오 디벨로퍼스에 `/api/auth/callback/kakao` 등록

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
