### PR TITLE
[FEAT] 바 차트 애니메이션 통일

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "lucide-react": "^0.513.0",
         "next": "15.3.2",
         "next-auth": "^4.24.11",
-        "next-swagger-doc": "^0.4.1",
+        "next-swagger-doc": "^0.4.0",
         "openai": "^5.1.1",
         "openapi3-ts": "^4.4.0",
         "react": "^19.0.0",

--- a/src/components/chart/PlanDetailBarChart.tsx
+++ b/src/components/chart/PlanDetailBarChart.tsx
@@ -10,6 +10,7 @@ import {
 } from "chart.js";
 import { Bar } from "react-chartjs-2";
 import { barChartOptions } from "./options/barChartOptions";
+import { useState, useEffect } from "react";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
@@ -24,11 +25,23 @@ const TendencyBarChart = ({
   name,
   labels = ["월정액", "데이터", "속도", "음성통화", "문자"],
 }: TendencyBarChartProps) => {
+  const [chartKey, setChartKey] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (data) {
+      setChartKey(Date.now());
+    }
+  }, [data]);
+
+  if (chartKey === null) {
+    return null;
+  }
+
   const datasets = Array.isArray(data[0])
     ? [
         {
           label: name,
-          data: (data as [number[], number[]])[0],
+          data: [...(data as [number[], number[]])[0]],
           backgroundColor: "rgba(255, 188, 31, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,
@@ -36,7 +49,7 @@ const TendencyBarChart = ({
         },
         {
           label: "내 요금제",
-          data: (data as [number[], number[]])[1],
+          data: [...(data as [number[], number[]])[1]],
           backgroundColor: "rgba(255, 99, 132, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,
@@ -46,7 +59,7 @@ const TendencyBarChart = ({
     : [
         {
           label: name,
-          data: data as number[],
+          data: [...(data as number[])],
           backgroundColor: "rgba(255, 188, 31, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,
@@ -56,7 +69,11 @@ const TendencyBarChart = ({
 
   return (
     <div className="w-full" style={{ height: 320 }}>
-      <Bar data={{ labels, datasets }} options={barChartOptions} />
+      <Bar
+        key={chartKey}
+        data={{ labels, datasets }}
+        options={barChartOptions}
+      />
     </div>
   );
 };

--- a/src/components/chart/options/barChartOptions.ts
+++ b/src/components/chart/options/barChartOptions.ts
@@ -8,10 +8,16 @@ export const barChartOptions: ChartOptions<"bar"> = {
   layout: {
     padding: { right: 24 },
   },
-  animation: {
-    duration: 1000,
-    easing: "easeOutQuart",
+  animations: {
+    x: {
+      duration: 1000,
+      easing: "easeOutQuart",
+    },
+    y: {
+      duration: 0,
+    },
   },
+
   scales: {
     x: {
       beginAtZero: true,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #139 

## 📝작업 내용

- Bar 차트 애니메이션 방식 수정

> 기존 animation 옵션에서 animations 옵션으로 변경하여 x축 기준 좌 → 우 애니메이션 적용
> y축 애니메이션을 제거하여 스케일 이동 시 발생하던 잔상 애니메이션 제거
데이터 불변성 유지 (immutable dataset 적용)

- PlanDetailBarChart 컴포넌트 렌더링 안정화

> chartKey 상태값을 활용하여 데이터 변경 시 차트를 강제 재생성하도록 변경 (Chart.js가 매번 새 데이터로 인식하도록 하여, 데이터 변경 시 매번 애니메이션이 동일하게 적용되도록 개선)
> 초기 렌더링 시 중복 렌더링 방지를 위해 chartKey === null 시에는 렌더링하지 않도록 처리

결론: 
1. 데이터 변경 시마다 기존 바 그래프 및 비교 바 그래프 모두 동일하게 좌 → 우 애니메이션 적용되도록 개선
2. 새로고침 및 페이지 이동 시 발생하던 초기 중복 렌더 현상 해결

### 스크린샷 (선택)

- 기존 애니메이션 통일 전
https://github.com/user-attachments/assets/809e62eb-9618-4641-9df8-4fd13a552a99

- 현재 애니메이션 통일 후
https://github.com/user-attachments/assets/0f6c10dd-5eb2-41ee-be93-fdfa81125209

## 💬리뷰 요구사항(선택)

> 애니메이션 통일하기 위해 Chart.js가 매번 새 데이터로 인식하도록 수정하다보니, 초기 렌더링 시 바 차트가 두 번 출력되는 듯한 문제가 있었습니다. 이를 해결하고 테스트를 많이 진행해서 문제가 해결되었다고 판단했지만 혹시 다른 팀원분들도 테스트하시다가 이와같은 버그가 발생하면 말씀 주세요!
