### PR TITLE
[BUG] radar chart 배경 영역 animation 오류 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "lucide-react": "^0.513.0",
         "next": "15.3.2",
         "next-auth": "^4.24.11",
-        "next-swagger-doc": "^0.4.1",
+        "next-swagger-doc": "^0.4.0",
         "openai": "^5.1.1",
         "openapi3-ts": "^4.4.0",
         "react": "^19.0.0",

--- a/src/components/chart/PlanDetailBarChart.tsx
+++ b/src/components/chart/PlanDetailBarChart.tsx
@@ -10,6 +10,7 @@ import {
 } from "chart.js";
 import { Bar } from "react-chartjs-2";
 import { barChartOptions } from "./options/barChartOptions";
+import { useState, useEffect } from "react";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
@@ -24,11 +25,23 @@ const TendencyBarChart = ({
   name,
   labels = ["월정액", "데이터", "속도", "음성통화", "문자"],
 }: TendencyBarChartProps) => {
+  const [chartKey, setChartKey] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (data) {
+      setChartKey(Date.now());
+    }
+  }, [data]);
+
+  if (chartKey === null) {
+    return null;
+  }
+
   const datasets = Array.isArray(data[0])
     ? [
         {
           label: name,
-          data: (data as [number[], number[]])[0],
+          data: [...(data as [number[], number[]])[0]],
           backgroundColor: "rgba(255, 188, 31, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,
@@ -36,7 +49,7 @@ const TendencyBarChart = ({
         },
         {
           label: "내 요금제",
-          data: (data as [number[], number[]])[1],
+          data: [...(data as [number[], number[]])[1]],
           backgroundColor: "rgba(255, 99, 132, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,
@@ -46,7 +59,7 @@ const TendencyBarChart = ({
     : [
         {
           label: name,
-          data: data as number[],
+          data: [...(data as number[])],
           backgroundColor: "rgba(255, 188, 31, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,
@@ -56,7 +69,11 @@ const TendencyBarChart = ({
 
   return (
     <div className="w-full" style={{ height: 320 }}>
-      <Bar data={{ labels, datasets }} options={barChartOptions} />
+      <Bar
+        key={chartKey}
+        data={{ labels, datasets }}
+        options={barChartOptions}
+      />
     </div>
   );
 };

--- a/src/components/chart/PlanDetailRadarChart.tsx
+++ b/src/components/chart/PlanDetailRadarChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React, { useState, useEffect } from "react";
 import {
   Chart as ChartJS,
   RadialLinearScale,
@@ -8,6 +9,7 @@ import {
   Filler,
   Tooltip,
   Legend,
+  ChartDataset,
 } from "chart.js";
 import { Radar } from "react-chartjs-2";
 import { getRadarChartOptions } from "./options/radarChartOptions";
@@ -28,12 +30,26 @@ interface TendencyRadarChartProps {
   labels?: string[];
 }
 
+const easing = "easeOutQuart" as const;
+
 const TendencyRadarChart = ({
   isRounded,
   data,
   name,
   labels = ["월정액", "데이터", "속도", "음성통화", "문자"],
 }: TendencyRadarChartProps) => {
+  const [chartKey, setChartKey] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (data) {
+      setChartKey(Date.now());
+    }
+  }, [data]);
+
+  if (chartKey === null) {
+    return null;
+  }
+
   const datasets = [
     {
       label: "기준값",
@@ -43,37 +59,44 @@ const TendencyRadarChart = ({
       borderColor: "rgba(200, 200, 255, 0.3)",
       borderWidth: 1,
       pointRadius: 0,
+      animations: false as unknown as ChartDataset<
+        "radar",
+        number[]
+      >["animations"],
     },
     ...(Array.isArray(data[0])
       ? [
           {
             label: name,
-            data: (data as [number[], number[]])[0],
+            data: [...(data as [number[], number[]])[0]],
             fill: true,
             backgroundColor: "rgba(255, 188, 31, 0.2)",
             borderColor: "rgba(255, 188, 31, 0.8)",
             borderWidth: 1.5,
             pointRadius: 0,
+            animations: { tension: { duration: 1000, easing } },
           },
           {
             label: "내 요금제",
-            data: (data as [number[], number[]])[1],
+            data: [...(data as [number[], number[]])[1]],
             fill: true,
             backgroundColor: "rgba(255, 99, 132, 0.2)",
             borderColor: "rgba(255, 99, 132, 0.8)",
             borderWidth: 1.5,
             pointRadius: 0,
+            animations: { tension: { duration: 1000, easing } },
           },
         ]
       : [
           {
             label: name,
-            data: data as number[],
+            data: [...(data as number[])],
             fill: true,
             backgroundColor: "rgba(255, 188, 31, 0.2)",
             borderColor: "rgba(255, 188, 31, 0.8)",
             borderWidth: 1.5,
             pointRadius: 0,
+            animations: { tension: { duration: 1000, easing } },
           },
         ]),
   ];
@@ -81,6 +104,7 @@ const TendencyRadarChart = ({
   return (
     <div className="h-[320px] w-full">
       <Radar
+        key={chartKey}
         data={{ labels, datasets }}
         options={getRadarChartOptions(isRounded)}
       />

--- a/src/components/chart/options/barChartOptions.ts
+++ b/src/components/chart/options/barChartOptions.ts
@@ -8,10 +8,16 @@ export const barChartOptions: ChartOptions<"bar"> = {
   layout: {
     padding: { right: 24 },
   },
-  animation: {
-    duration: 1000,
-    easing: "easeOutQuart",
+  animations: {
+    x: {
+      duration: 1000,
+      easing: "easeOutQuart",
+    },
+    y: {
+      duration: 0,
+    },
   },
+
   scales: {
     x: {
       beginAtZero: true,

--- a/src/components/chart/options/radarChartOptions.ts
+++ b/src/components/chart/options/radarChartOptions.ts
@@ -1,6 +1,6 @@
 import { ChartOptions } from "chart.js";
 
-// Radar 차트 옵션 정의 (dataset 개별 애니메이션으로 관리 중이므로, global animation은 없음)
+// Radar 차트 옵션 정의
 export const getRadarChartOptions = (
   isRounded: boolean
 ): ChartOptions<"radar"> => ({
@@ -15,7 +15,7 @@ export const getRadarChartOptions = (
         stepSize: 20,
         color: "#888",
         backdropColor: "transparent",
-        font: { size: 8, weight: 400 }, // weight를 string으로 변경 (Chart.js v4에서 타입 안정성)
+        font: { size: 8, weight: 400 },
         padding: 18,
         z: 1,
         display: true,
@@ -27,7 +27,7 @@ export const getRadarChartOptions = (
       angleLines: { color: "rgba(0, 0, 0, 0.1)" },
       pointLabels: {
         color: "#666",
-        font: { size: 12, weight: 500 }, // 여기도 string으로 통일
+        font: { size: 12, weight: 500 },
       },
     },
   },

--- a/src/components/chart/options/radarChartOptions.ts
+++ b/src/components/chart/options/radarChartOptions.ts
@@ -1,6 +1,6 @@
 import { ChartOptions } from "chart.js";
 
-//Radar 차트 옵션 정의
+// Radar 차트 옵션 정의 (dataset 개별 애니메이션으로 관리 중이므로, global animation은 없음)
 export const getRadarChartOptions = (
   isRounded: boolean
 ): ChartOptions<"radar"> => ({
@@ -15,27 +15,23 @@ export const getRadarChartOptions = (
         stepSize: 20,
         color: "#888",
         backdropColor: "transparent",
-        font: { size: 8, weight: 400 },
+        font: { size: 8, weight: 400 }, // weight를 string으로 변경 (Chart.js v4에서 타입 안정성)
         padding: 18,
         z: 1,
         display: true,
       },
       grid: {
         color: "rgba(0, 0, 0, 0.1)",
-        circular: !isRounded, //옵션 파라미터에 따라 원형/다각형 결정
+        circular: !isRounded, // 옵션 파라미터에 따라 원형/다각형 결정
       },
       angleLines: { color: "rgba(0, 0, 0, 0.1)" },
       pointLabels: {
         color: "#666",
-        font: { size: 12, weight: 500 },
+        font: { size: 12, weight: 500 }, // 여기도 string으로 통일
       },
     },
   },
   plugins: {
     legend: { display: false },
-  },
-  animation: {
-    duration: 1000,
-    easing: "easeOutQuart",
   },
 });

--- a/src/components/planDetail/PlanInfo.tsx
+++ b/src/components/planDetail/PlanInfo.tsx
@@ -14,7 +14,7 @@ import { PlanDetailData } from "@/types/planDetail";
 export default function PlanInfo({ data, mode, onChangeMode }: PlanInfoProps) {
   return (
     <div className="px-8">
-      <h1 className="pt-5 text-[1.75rem] leading-tight font-bold text-gray-900">
+      <h1 className="pt-5 text-[1.75rem] leading-snug font-bold [word-break:keep-all] text-gray-900">
         {data.name}
       </h1>
       <p className="text-[1rem] font-semibold text-gray-900">{data.price}</p>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #147 

## 📝작업 내용

- RadarChart 배경 영역 데이터셋 애니메이션 제거

> 기존 tension animation 설정 → animations: false로 전체 애니메이션 비활성화
기준 데이터셋 (배경 영역)이 mount될 때 즉시 출력되도록 수정
배경 영역, 내 요금제 그래프, 추천 요금제 그래프를 각각 분리하여 애니메이션 적용

(+ bar chart와 통일성을 고려하여, 마운트 시 bar chart와 마찬가지로 기존 그래프도 애니메이션 적용)

>렌더링 key 관리 로직 유지
chartKey를 활용하여 데이터 변경 시마다 Chart 강제 재생성
마운트 시마다 애니메이션 재실행

### 스크린샷

- RadarChart 배경 애니메이션 제거 영상
https://github.com/user-attachments/assets/7a9ab2bf-95c8-4c7b-b634-2c8b28c85a3b

---

- Info Title 개행 처리 완료 이미지
![image](https://github.com/user-attachments/assets/531f92ef-3f93-44fb-b4a0-72749fbeaabe)

## 추가 작업

- [x] Info Title 개행 문제 해결

> 타이틀 영역에 word-break: keep-all 적용하여 한글 단어 단위 줄바꿈 처리
(수정 내용이 짧아서 해당 PR에 commit해서 추가했습니다!)
