### PR TITLE
#153 refactor: DB 재구성 및 툴팁 개선

### DIFF
--- a/src/components/chart/PlanDetailBarChart.tsx
+++ b/src/components/chart/PlanDetailBarChart.tsx
@@ -16,12 +16,14 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
 interface TendencyBarChartProps {
   data: number[] | [number[], number[]];
+  rawData: number[] | [number[], number[]];
   name: string;
   labels?: string[];
 }
 
 const TendencyBarChart = ({
   data,
+  rawData,
   name,
   labels = ["월정액", "데이터", "속도", "음성통화", "문자"],
 }: TendencyBarChartProps) => {
@@ -42,6 +44,7 @@ const TendencyBarChart = ({
         {
           label: name,
           data: [...(data as [number[], number[]])[0]],
+          rawData: [...(rawData as [number[], number[]])[0]],
           backgroundColor: "rgba(255, 188, 31, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,
@@ -50,6 +53,7 @@ const TendencyBarChart = ({
         {
           label: "내 요금제",
           data: [...(data as [number[], number[]])[1]],
+          rawData: [...(rawData as [number[], number[]])[1]],
           backgroundColor: "rgba(255, 99, 132, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,
@@ -60,6 +64,7 @@ const TendencyBarChart = ({
         {
           label: name,
           data: [...(data as number[])],
+          rawData: [...(rawData as number[])],
           backgroundColor: "rgba(255, 188, 31, 0.6)",
           borderWidth: 0,
           categoryPercentage: 0.4,

--- a/src/components/chart/options/barChartOptions.ts
+++ b/src/components/chart/options/barChartOptions.ts
@@ -49,9 +49,29 @@ export const barChartOptions: ChartOptions<"bar"> = {
     tooltip: {
       callbacks: {
         label: (context: TooltipItem<"bar">) => {
-          const label = context.dataset.label || "";
-          const value = context.parsed.x;
-          return `${label}: ${value}%`;
+          const dataset = context.dataset as any;
+          const index = context.dataIndex;
+          const rawData = dataset.rawData?.[index];
+
+          //만약 rawData가 없는 경우 fallback 처리
+          if (rawData === undefined) {
+            return `${context.dataset.label}: ${context.parsed.x}%`;
+          }
+
+          switch (context.label) {
+            case "월정액":
+              return `월 ${rawData}원`;
+            case "데이터":
+              return `월 ${rawData}MB`;
+            case "속도":
+              return `다 쓰면 ${rawData}Kbps`;
+            case "음성통화":
+              return `${rawData}분`;
+            case "문자":
+              return `혜택 ${rawData}원`;
+            default:
+              return `${rawData}`;
+          }
         },
       },
     },

--- a/src/components/planDetail/PlanCharts.tsx
+++ b/src/components/planDetail/PlanCharts.tsx
@@ -25,6 +25,7 @@ export default function PlanCharts({ data, mode }: PlanChartsProps) {
       <div className="ml-[2rem] h-80 w-[85%]">
         <TendencyBarChart
           data={mode === "basic" ? data.bar : [data.bar, data.compare]}
+          rawData={mode === "basic" ? data.raw : [data.raw, data.compareRaw]}
           name={data.name}
         />
       </div>

--- a/src/types/planDetail.ts
+++ b/src/types/planDetail.ts
@@ -10,6 +10,8 @@ export interface PlanDetailData {
   tags: string[];
   radar: number[];
   bar: number[];
+  raw: number[];
   compare: number[];
+  compareRaw: number[];
   benefits: Benefit[];
 }

--- a/src/utils/mapPlanToDetailData.ts
+++ b/src/utils/mapPlanToDetailData.ts
@@ -37,21 +37,24 @@ export function mapPlanToDetailData(
   plan: PlanDBApiResponse,
   context: ScoreContext
 ): PlanDetailData {
-  const priceScore = 100 - normalize(plan.price, 10000, 105000);
-  const dataScore = normalize(
-    (plan.dataAmountMb ?? 0) > 999999 ? 300000 : (plan.dataAmountMb ?? 0),
-    0,
-    300000
-  );
-  const speedScore = normalize(plan.overageSpeedMbps ?? 0, 0, 5);
-  const voiceScore = normalize(
-    plan.voiceMinutes < 0 ? 9999 : (plan.voiceMinutes ?? 0),
-    0,
-    400
-  );
-  const smsScore = plan.smsIncluded ? 100 : 0;
+  const priceScore = normalize(plan.price, 0, 105000);
+  const dataScore = normalize(plan.dataAmountMb ?? 0, 0, 300000);
+  const speedScore = normalize(plan.overageSpeedMbps ?? 0, 0, 8000);
+  const voiceScore = normalize(plan.voiceMinutes ?? 0, 0, 400);
+  const smsScore = normalize(plan.smsIncluded ? 45200 : 0, 0, 45200);
 
   const scoreArray = [priceScore, dataScore, speedScore, voiceScore, smsScore];
+
+  const rawArray = [
+    plan.price,
+    plan.dataAmountMb ?? 0,
+    plan.overageSpeedMbps ?? 0,
+    plan.voiceMinutes ?? 0,
+    plan.smsIncluded ? 45200 : 0,
+  ];
+
+  const compareArray = [40, 82, 84, 43, 59];
+  const compareRawArray = [30000, 50000, 1000, 250, 10000];
 
   return {
     name: plan.name,
@@ -59,7 +62,9 @@ export function mapPlanToDetailData(
     tags: ["정제된 태그", plan.networkType, "혜택 풍부"],
     radar: scoreArray,
     bar: scoreArray,
-    compare: [40, 82, 84, 43, 59],
+    raw: rawArray,
+    compare: compareArray,
+    compareRaw: compareRawArray,
     benefits: getBenefits(plan.subscriptionServices),
   };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #153 

## 📝작업 내용

**BarChart 툴팁 내용을 기존 % 스케일 대신 DB 원본 데이터 기준으로 표시하도록 개선**

- 툴팁 표시 형식:
>월정액 → 월 {price}원
데이터 → 월 {dataAmountMb}MB
속도 → 다 쓰면 {overageSpeedMbps}Kbps
음성통화 → {voiceMinutes}분
문자 → 혜택 {smsIncluded}원

**BarChart datasets에 rawData 필드 추가 → 툴팁에서 원본 데이터 참조 가능하도록 구조 확장**
> PlanDetailData 타입에 raw 및 compareRaw 필드 추가
호출 시 rawData 전달하도록 수정

**DB 재구성 -> 실제 LG U+ 홈페이지 요금제와 다른 내용의 더미 데이터 컨셉**



### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/bf1d8174-9afe-4721-9521-c7b8371b36ff)
