### PR TITLE
[REFACTOR] 차트 시각화 개선

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,7 +51,7 @@ model Plan {
   dataAmountMb         Float       @default(0)
   overageSpeedMbps     Float?
   voiceMinutes         Int         @default(-1)
-  smsIncluded          Boolean     @default(false)
+  smsIncluded          Int         @default(0)
   networkType          NetworkType @default(LTE)
   subscriptionServices Json        @default("[]")
 

--- a/src/types/PlanData.ts
+++ b/src/types/PlanData.ts
@@ -8,7 +8,7 @@ export interface PlanDBApiResponse {
   dataAmountMb: number;
   overageSpeedMbps: number | null;
   voiceMinutes: number;
-  smsIncluded: boolean;
+  smsIncluded: number;
   networkType: "LTE" | "5G";
   subscriptionServices: string[];
 }

--- a/src/utils/mapPlanToDetailData.ts
+++ b/src/utils/mapPlanToDetailData.ts
@@ -41,7 +41,7 @@ export function mapPlanToDetailData(
   const dataScore = normalize(plan.dataAmountMb ?? 0, 0, 300000);
   const speedScore = normalize(plan.overageSpeedMbps ?? 0, 0, 8000);
   const voiceScore = normalize(plan.voiceMinutes ?? 0, 0, 400);
-  const smsScore = normalize(plan.smsIncluded ? 45200 : 0, 0, 45200);
+  const smsScore = normalize(plan.smsIncluded ?? 0, 0, 45200);
 
   const scoreArray = [priceScore, dataScore, speedScore, voiceScore, smsScore];
 
@@ -50,7 +50,7 @@ export function mapPlanToDetailData(
     plan.dataAmountMb ?? 0,
     plan.overageSpeedMbps ?? 0,
     plan.voiceMinutes ?? 0,
-    plan.smsIncluded ? 45200 : 0,
+    plan.smsIncluded ?? 0,
   ];
 
   const compareArray = [40, 82, 84, 43, 59];


### PR DESCRIPTION
## #️⃣연관된 이슈

> #170 

## 📝작업 내용

- Prisma 스키마 수정
> Plan 모델의 smsIncluded 필드를 Boolean → Int로 변경하여 DB 실데이터와 타입 일치

- Prisma Client 재생성 (npx prisma generate)
> API 응답 데이터 수정
Prisma에서 넘어오는 smsIncluded가 number 타입으로 안전하게 반환되도록 변경

- 프론트 타입 수정
> PlanDBApiResponse에서 smsIncluded: boolean → smsIncluded: number로 타입 변경

- mapPlanToDetailData()에서 smsIncluded 정규화 로직 수정

- BarChart 툴팁 정상화
- 툴팁에서 혜택 {smsIncluded}원 정상 출력

### 스크린샷

![image](https://github.com/user-attachments/assets/3bb8e9c4-bdb1-46fb-b013-ab8b73d11cd1)


## 💬리뷰 요구사항(선택)

> 추후 더 정리하고 추가 작업 진행하겠습니다~
