### PR TITLE
[FEAT] 랜딩페이지 구현

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function onBoardingPage() {
+  return <div></div>;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,29 +1,81 @@
 "use client";
 
-import { useBleScanner } from "@/hooks/useBleScanner";
-import { useNearbySocket } from "@/hooks/useNearbySocket";
-import { useState } from "react";
+import CharacterModel from "@/components/chat/CharacterModel";
+import TopGradient from "@/components/planDetail/TopGradient";
+import { Button } from "@/components/ui/button";
+import { OrbitControls } from "@react-three/drei";
+import { Canvas } from "@react-three/fiber";
+import { signIn, useSession } from "next-auth/react";
+import Image from "next/image";
+import { usePathname, useRouter } from "next/navigation";
 
 export default function Home() {
-  const [logs, setLogs] = useState<any[]>([]);
-  const wsRef = useNearbySocket((data) => {
-    setLogs((prev) => [...prev, data]);
-  });
-  useBleScanner(wsRef.current); //WebSocket에 BLE 거리 전송
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const pathname = usePathname();
+
+  const handleLogin = () => {
+    signIn("kakao", { callbackUrl: pathname });
+  };
+
+  const handleExplore = () => {
+    session ? router.push("/home") : router.push("/onboarding");
+  };
+
+  const tmp = () => {
+    console.log("랜딩페이지 무너 클릭");
+  };
+
   return (
-    <div className="h-screen w-full">
-      <main>
-        <div className="p-4">
-          <h1 className="text-xl font-bold">Nearby User Logs</h1>
-          <ul className="mt-4">
-            {logs.map((log, idx) => (
-              <li key={idx}>
-                🛰️ {log.userId} | 거리: {log.distance}m
-              </li>
-            ))}
-          </ul>
-        </div>
-      </main>
+    <div className="relative flex min-h-screen flex-col items-center bg-gradient-to-b from-[#fff1e5] to-[#ffe5f1] px-4">
+      <TopGradient />
+
+      {/* 무물 로고 영역 */}
+      <div className="z-20 mt-20 flex w-full justify-center">
+        <Image
+          src="/assets/icons/logo.png"
+          alt="logo"
+          width={120}
+          height={120}
+        />
+      </div>
+
+      {/* 캐릭터 영역 */}
+      <Canvas
+        style={{ width: "60%", height: "40%" }}
+        camera={{ position: [0, 2, 4], fov: 35 }}>
+        <ambientLight intensity={0.9} />
+        <directionalLight position={[2, 2, 5]} intensity={1.2} />
+        <CharacterModel onClick={tmp} isSpeaking={false} isThinking={false} />
+        <OrbitControls
+          enablePan={false}
+          enableZoom={false}
+          enableRotate={false}
+        />
+      </Canvas>
+
+      {/* 버튼 영역 */}
+      <div className="z-10 mt-auto mb-10 flex w-full max-w-xs flex-col gap-4 font-semibold">
+        <Button
+          onClick={handleLogin}
+          variant="pink"
+          className="flex items-center justify-center gap-2 py-6 text-lg font-semibold text-white">
+          <Image
+            src={"/assets/icons/message-circle.png"}
+            alt="메세지"
+            width={15}
+            height={15}
+          />
+          카카오로 시작하기
+        </Button>
+
+        <Button
+          onClick={handleExplore}
+          variant="pink"
+          className="flex items-center justify-center py-6 text-lg font-semibold text-white">
+          둘러보기
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -20,6 +20,7 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        pink: "rounded-lg bg-pink-400 py-3 text-black shadow-md",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -33,7 +34,7 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 function Button({
   className,
@@ -43,9 +44,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -53,7 +54,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };


### PR DESCRIPTION
## #️⃣연관된 이슈
#167 

## 📝작업 내용
- [x] 랜딩 페이지 UI 구현
- [x] TopGradient 배경 적용
- [x] CharacterScene 컴포넌트 수정으로 무너 3D 애니메이션 적용 
- [x] 카카오 로그인 후 랜딩 페이지로 리다이렉트
- [x] 카카오톡 리다이렉트
- [x] 둘러보기 버튼 클릭시 로그인 O : 홈화면, 로그인 X: 온보딩 페이지로 이동
- [x] 버튼 shadcn 커스텀

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/832bf664-a464-4a15-8236-c53c70d1bf67)

## 💬리뷰 요구사항(선택)
TopGradient만 넣었고, BottomGradient는 안 넣는게 이쁜 것 같아 안 넣었습니다.
