### PR TITLE
[FEAT] 무물 로고 컴포넌트화

### DIFF
--- a/src/app/meme-test/page.tsx
+++ b/src/app/meme-test/page.tsx
@@ -34,7 +34,7 @@ export default function TestHomePage() {
 
   return (
     <div className="flex h-full w-full flex-col bg-pink-200 px-0">
-      <div className="pl-5">
+      <div className="pt-2 pl-5">
         <HeadLogo />
       </div>
 

--- a/src/app/meme-test/page.tsx
+++ b/src/app/meme-test/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import HeadLogo from "@/components/common/headlogo";
 import ShareSection from "@/components/meme/shareSection";
 import { useAnimatedCount } from "@/hooks/useAnimatedCount";
 import { useGetTypeRankQuery } from "@/hooks/useGetTypeRankQuery";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 
 export default function TestHomePage() {
   const router = useRouter();
@@ -34,9 +34,8 @@ export default function TestHomePage() {
 
   return (
     <div className="flex h-full w-full flex-col bg-pink-200 px-0">
-      {/* 상단 로고 영역 */}
-      <div className="flex items-start px-3">
-        <img src="/assets/icons/logo.png" alt="logo" className="w-20" />
+      <div className="pl-5">
+        <HeadLogo />
       </div>
 
       {/* 중앙 콘텐츠 */}

--- a/src/components/common/headlogo.tsx
+++ b/src/components/common/headlogo.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function HeadLogo() {
+  const router = useRouter();
+  const handleToHome = () => {
+    router.push("/home");
+  };
+
+  return (
+    <div className="flex cursor-pointer items-center justify-between">
+      {/* 좌측 로고 */}
+      <img
+        src="/assets/icons/logo.png"
+        alt="logo"
+        className="h-auto w-18"
+        onClick={handleToHome}
+      />
+    </div>
+  );
+}

--- a/src/components/common/headlogo.tsx
+++ b/src/components/common/headlogo.tsx
@@ -9,7 +9,7 @@ export default function HeadLogo() {
   };
 
   return (
-    <div className="flex cursor-pointer items-center justify-between">
+    <div className="cursor-pointer">
       {/* 좌측 로고 */}
       <img
         src="/assets/icons/logo.png"

--- a/src/components/home/HomeHeader.tsx
+++ b/src/components/home/HomeHeader.tsx
@@ -4,6 +4,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useGetUserCharacterProfile } from "@/hooks/useGetUserCharacterProfile";
 import { signIn, useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
+import HeadLogo from "../common/headlogo";
 
 export default function HomeHeader() {
   const { data: session } = useSession();
@@ -25,7 +26,7 @@ export default function HomeHeader() {
     <div className="w-full pt-2">
       <div className="flex items-center justify-between">
         {/* 좌측 로고 */}
-        <img src="/assets/icons/logo.png" alt="logo" className="h-auto w-18" />
+        <HeadLogo />
 
         {/* 우측: 로그인 상태에 따라 표시 */}
         {isLoggedIn ? (


### PR DESCRIPTION
## #️⃣연관된 이슈
#173 

## 📝작업 내용
무물 로고가 좌측 상단에 공통으로 사용됨
- 무물 로고 컴포넌트화

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/78be27ad-9290-4dd4-8475-f13c5aa64acf)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
