### PR TITLE
[BUG] 시크릿모드 및 공유 링크에서 밈테스트 시작 시 404 오류 발생 문제 해결

### DIFF
--- a/src/app/meme-test/page.tsx
+++ b/src/app/meme-test/page.tsx
@@ -4,7 +4,7 @@ import HeadLogo from "@/components/common/headlogo";
 import ShareSection from "@/components/meme/shareSection";
 import { useAnimatedCount } from "@/hooks/useAnimatedCount";
 import { useGetTypeRankQuery } from "@/hooks/useGetTypeRankQuery";
-import { useSession } from "next-auth/react";
+import { signIn, useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
 export default function TestHomePage() {
@@ -24,11 +24,11 @@ export default function TestHomePage() {
 
   const handleStart = () => {
     const randomId = Math.random().toString(36).substring(2, 10);
+    const callbackUrl = `/meme-test/${randomId}`;
     if (!session) {
-      const callbackUrl = `/meme-test/${randomId}`;
-      router.push(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+      signIn("kakao", { callbackUrl });
     } else {
-      router.push(`/meme-test/${randomId}`);
+      router.push(callbackUrl);
     }
   };
 

--- a/src/app/meme-test/result/[id]/page.tsx
+++ b/src/app/meme-test/result/[id]/page.tsx
@@ -192,7 +192,7 @@ export default function ResultPage() {
           />
           <button
             onClick={handleOpenHomeInNewTab}
-            className="rounded-full bg-pink-400 px-9 py-4 font-bold text-black">
+            className="cursor-pointer rounded-full bg-pink-400 px-9 py-4 font-bold text-black">
             무너에게 요금제 상담하기
           </button>
         </div>
@@ -250,12 +250,12 @@ export default function ResultPage() {
           className="mt-6 flex w-[90%] flex-col gap-3 text-2xl">
           <button
             onClick={handleNavigateToMemeTest}
-            className="rounded-lg bg-pink-400 py-3 text-black shadow-md">
+            className="cursor-pointer rounded-lg bg-pink-400 py-3 text-black shadow-md">
             테스트 다시하기
           </button>
           <button
             onClick={handleNavigateToRankPage}
-            className="rounded-lg bg-yellow-300 py-3 text-black shadow-md">
+            className="cursor-pointer rounded-lg bg-yellow-300 py-3 text-black shadow-md">
             전체 유형 확인하기
           </button>
         </div>

--- a/src/app/meme-test/result/[id]/page.tsx
+++ b/src/app/meme-test/result/[id]/page.tsx
@@ -227,7 +227,7 @@ export default function ResultPage() {
               title="내 결과 공유하기"
               count={data?.sharedCount || 0}
               id={decryptedId}
-              shareUrl={`/meme-test/result/${encryptedId}`}
+              shareUrl={`/result/${encryptedId}`}
             />
             <div className="rounded-md p-3 text-[11px] leading-tight text-gray-800">
               <ul className="list-disc space-y-1 text-left">

--- a/src/components/meme/ChoiceList.tsx
+++ b/src/components/meme/ChoiceList.tsx
@@ -14,7 +14,7 @@ export default function ChoiceList({
         <Button
           key={choice.id}
           variant="outline"
-          className="h-[3.75rem] w-[20rem] rounded-full border-1 border-pink-400 bg-white font-[17px] hover:bg-pink-300"
+          className="h-[3.5rem] w-[20rem] cursor-pointer rounded-full border-1 border-pink-400 bg-white font-[17px] hover:bg-pink-300"
           onClick={() => onSelect(choice)}>
           {choice.text}
         </Button>

--- a/src/components/meme/Header.tsx
+++ b/src/components/meme/Header.tsx
@@ -7,7 +7,7 @@ export default function Header({ onBack }: { onBack: () => void }) {
   return (
     <header className="sticky top-0 z-100 flex h-12 w-full items-center justify-between bg-yellow-200 px-4">
       <div className="flex items-center">
-        <ChevronLeft onClick={onBack} className="h-5 w-5" />
+        <ChevronLeft onClick={onBack} className="h-5 w-5 cursor-pointer" />
       </div>
       <div
         style={{ fontFamily: "kkubulim" }}


### PR DESCRIPTION
## #️⃣연관된 이슈
#173 

## 📝작업 내용
- 밈 테스트 시작하기 버튼 클릭 시 로그인 여부 판단 후,
로그인하지 않은 경우 /login으로 라우팅하던 방식을 → signIn("kakao") 방식으로 변경
- 불필요한 /login 경로 접근 제거 및 시크릿모드/카카오 인앱 브라우저에서 발생하던 404 이슈 해결
- 로그인 후 테스트 진행 경로(callbackUrl)는 기존처럼 유지되도록 처리

```ts
// 변경 전
router.push(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);

// 변경 후
signIn("kakao", { callbackUrl });
```

- 별도의 /login 페이지 없이도 로그인 흐름이 작동하도록 개선
- 공유 링크를 클릭해 접속한 사용자가 로그인하지 않았더라도, 404 없이 로그인 후 정상적으로 테스트 시작 가능

- 클릭 이벤트 존재하는 버튼에 `cursor-pointer`추가
