### PR TITLE
[FEAT] 온보딩 마크업 및 global.css 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -174,6 +174,12 @@ body {
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
 }
+.mask-gradient-blur {
+  -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+  mask-mode: alpha;
+  mask-repeat: no-repeat;
+}
 
 @layer base {
   * {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,5 +1,155 @@
+"use client";
 import React from "react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { motion, AnimatePresence } from "framer-motion";
+import { useRouter } from "next/navigation";
 
+const slides = [
+  {
+    id: 1,
+    title: "내게 딱 맞는 AI 요금제 추천",
+    description: "복잡한 요금제,\nAI가 당신에게 꼭 맞는 걸 찾아드려요",
+    highlight: "AI 요금제 추천",
+    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
+    buttonText: "다음으로",
+  },
+  {
+    id: 2,
+    title: "나의 콘텐츠 성향은?",
+    description: "영상부터 음악까지, 당신의 취향을 반영한 요금제",
+    highlight: "콘텐츠",
+    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
+    buttonText: "시작하기",
+  },
+  {
+    id: 3,
+    title: "나의 콘텐츠 성향은?",
+    description: "영상부터 음악까지, 당신의 취향을 반영한 요금제",
+    highlight: "콘텐츠",
+    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
+    buttonText: "시작하기",
+  },
+  {
+    id: 4,
+    title: "나의 콘텐츠 성향은?",
+    description: "영상부터 음악까지, 당신의 취향을 반영한 요금제",
+    highlight: "콘텐츠",
+    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
+    buttonText: "시작하기",
+  },
+  {
+    id: 5,
+    title: "나의 콘텐츠 성향은?",
+    description: "영상부터 음악까지, 당신의 취향을 반영한 요금제",
+    highlight: "콘텐츠",
+    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
+    buttonText: "시작하기",
+  },
+];
+
+// 강조 텍스트 렌더링 유틸
+function HighlightedText({
+  text,
+  highlight,
+}: {
+  text: string;
+  highlight: string;
+}) {
+  const parts = text.split(highlight);
+  return (
+    <>
+      {parts[0]}
+      <span className="text-red-500">{highlight}</span>
+      {parts[1]}
+    </>
+  );
+}
+function MultilineText({ text }: { text: string }) {
+  return (
+    <>
+      {text.split("\n").map((line, index) => (
+        <React.Fragment key={index}>
+          {line}
+          <br />
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
 export default function onBoardingPage() {
-  return <div></div>;
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const [direction, setDirection] = useState<"left" | "right">("right");
+  const router = useRouter();
+  const goToSlide = (nextIndex: number) => {
+    setDirection(nextIndex > currentSlide ? "right" : "left");
+    setCurrentSlide(nextIndex);
+  };
+
+  const handleLast = () => {
+    if (currentSlide < slides.length - 1) {
+      setCurrentSlide(currentSlide + 1);
+    } else {
+      router.push("/home");
+    }
+  };
+
+  return (
+    <div className="relative flex h-[100dvh] w-full flex-col justify-start bg-white">
+      {/* 상단 이미지 */}
+      <div className="relative h-[60%] w-full overflow-hidden">
+        <AnimatePresence mode="wait">
+          <motion.img
+            key={slides[currentSlide].id}
+            src={slides[currentSlide].image}
+            alt="slide"
+            className="mask-gradient-blur h-full w-full rounded-b-[32px] object-cover"
+            initial={{ opacity: 0, x: direction === "right" ? 50 : -50 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: direction === "right" ? -50 : 50 }}
+            transition={{ duration: 0.5 }}
+          />
+        </AnimatePresence>
+      </div>
+
+      {/* 텍스트 영역 */}
+      <div className="mt-6 ml-6 flex flex-col gap-2 text-left">
+        <p className="text-sm text-gray-800">
+          <MultilineText text={slides[currentSlide].description} />
+        </p>
+        <h2 className="text-2xl leading-snug font-bold">
+          <HighlightedText
+            text={slides[currentSlide].title}
+            highlight={slides[currentSlide].highlight}
+          />
+        </h2>
+      </div>
+
+      {/* 버튼 + 인디케이터 묶음 - 하단 고정 */}
+      <div className="absolute bottom-8 left-0 w-full px-6">
+        {/* 인디케이터 */}
+        <div className="mb-4 flex items-center justify-center gap-2">
+          {slides.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => goToSlide(i)}
+              className={cn(
+                "h-2 w-2 rounded-full transition-all",
+                i === currentSlide ? "bg-black" : "bg-gray-300"
+              )}
+              aria-label={`Go to slide ${i + 1}`}
+            />
+          ))}
+        </div>
+
+        {/* 버튼 */}
+        <div className="flex justify-center">
+          <Button className="w-[70%]" onClick={handleLast}>
+            {slides[currentSlide].buttonText}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -12,44 +12,38 @@ const slides = [
     title: "내게 딱 맞는 AI 요금제 추천",
     description: "복잡한 요금제,\nAI가 당신에게 꼭 맞는 걸 찾아드려요",
     highlight: "AI 요금제 추천",
-    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
-    buttonText: "다음으로",
+    image: "/assets/icons/moomool_banner.png",
   },
   {
     id: 2,
     title: "나의 콘텐츠 성향은?",
-    description: "영상부터 음악까지, 당신의 취향을 반영한 요금제",
+    description: "영상부터 음악까지,\n당신의 취향을 반영한 요금제",
     highlight: "콘텐츠",
-    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
-    buttonText: "시작하기",
+    image: "/assets/icons/moomool_banner.png",
   },
   {
     id: 3,
     title: "나의 콘텐츠 성향은?",
-    description: "영상부터 음악까지, 당신의 취향을 반영한 요금제",
+    description: "영상부터 음악까지,\n당신의 취향을 반영한 요금제",
     highlight: "콘텐츠",
-    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
-    buttonText: "시작하기",
+    image: "/assets/icons/moomool_banner.png",
   },
   {
     id: 4,
     title: "나의 콘텐츠 성향은?",
-    description: "영상부터 음악까지, 당신의 취향을 반영한 요금제",
+    description: "영상부터 음악까지,\n당신의 취향을 반영한 요금제",
     highlight: "콘텐츠",
-    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
-    buttonText: "시작하기",
+    image: "/assets/icons/moomool_banner.png",
   },
   {
     id: 5,
     title: "나의 콘텐츠 성향은?",
-    description: "영상부터 음악까지, 당신의 취향을 반영한 요금제",
+    description: "영상부터 음악까지,\n당신의 취향을 반영한 요금제",
     highlight: "콘텐츠",
-    image: "/assets/icons/moomool_banner.png", // 실제 이미지 경로로 교체 예정
-    buttonText: "시작하기",
+    image: "/assets/icons/moomool_banner.png",
   },
 ];
 
-// 강조 텍스트 렌더링 유틸
 function HighlightedText({
   text,
   highlight,
@@ -66,6 +60,7 @@ function HighlightedText({
     </>
   );
 }
+
 function MultilineText({ text }: { text: string }) {
   return (
     <>
@@ -78,22 +73,35 @@ function MultilineText({ text }: { text: string }) {
     </>
   );
 }
+
 export default function onBoardingPage() {
-  const [currentSlide, setCurrentSlide] = useState(0);
-  const [direction, setDirection] = useState<"left" | "right">("right");
+  const [slideState, setSlideState] = useState({
+    index: 0,
+    direction: "right" as "left" | "right",
+  });
   const router = useRouter();
+
   const goToSlide = (nextIndex: number) => {
-    setDirection(nextIndex > currentSlide ? "right" : "left");
-    setCurrentSlide(nextIndex);
+    setSlideState((prev) => ({
+      index: nextIndex,
+      direction: nextIndex > prev.index ? "right" : "left",
+    }));
   };
 
   const handleLast = () => {
-    if (currentSlide < slides.length - 1) {
-      setCurrentSlide(currentSlide + 1);
+    if (slideState.index < slides.length - 1) {
+      setSlideState((prev) => ({
+        index: prev.index + 1,
+        direction: "right",
+      }));
     } else {
       router.push("/home");
     }
   };
+
+  const currentSlide = slideState.index;
+  const direction = slideState.direction;
+  const isLastSlide = currentSlide === slides.length - 1;
 
   return (
     <div className="relative flex h-[100dvh] w-full flex-col justify-start bg-white">
@@ -146,7 +154,7 @@ export default function onBoardingPage() {
         {/* 버튼 */}
         <div className="flex justify-center">
           <Button className="w-[70%]" onClick={handleLast}>
-            {slides[currentSlide].buttonText}
+            {isLastSlide ? "시작하기" : "다음으로"}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #201 

## 📝작업 내용

- 온보딩 마크업
- `global.css` 에 블러 처리 관련 설정 추가
- slides 내 buttonText 옵션 삭제 후 슬라이드 순서에 따라 버튼 텍스트 변경 (다음으로 / 시작하기)

## 스크린샷 (선택)

![화면 기록 2025-06-18 오후 3 41 53](https://github.com/user-attachments/assets/cd6a91a7-3f80-4bd9-beac-a09e7bf35f66)


## 💬리뷰 요구사항(선택)

온보딩 데이터는 임의로 추가했으며 실제 데이터 넣을 때 파일 분리 예정입니다
