### PR TITLE
[FEAT] 챗봇 세션 조회 및 말풍선 UI 개선

### DIFF
--- a/src/app/api/chat-session/route.ts
+++ b/src/app/api/chat-session/route.ts
@@ -2,6 +2,31 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
 // GET: 최근 채팅 세션 5개
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("userId");
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "userId가 필요합니다." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const sessions = await prisma.chatSession.findMany({
+      where: { user_id: userId },
+      orderBy: { created_at: "desc" },
+      take: 5,
+    });
+
+    return NextResponse.json(sessions);
+  } catch (err) {
+    console.error("[CHAT_SESSION_GET_ERROR]", err);
+    return NextResponse.json({ error: "서버 오류" }, { status: 500 });
+  }
+}
+
 export async function POST(req: NextRequest) {
   try {
     const { userId, messages } = await req.json();

--- a/src/components/common/FloatingChatbotButton.tsx
+++ b/src/components/common/FloatingChatbotButton.tsx
@@ -1,15 +1,23 @@
-import CharacterModel from "../chat/CharacterModel";
-import { Canvas } from "@react-three/fiber";
-import { useRouter } from "next/navigation";
+"use client";
+
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { useRouter } from "next/navigation";
+import { Canvas } from "@react-three/fiber";
+import CharacterModel from "../chat/CharacterModel";
+import { useGetRecentChatSessions } from "@/hooks/useGetRecentChatSessions";
+import { useSession } from "next-auth/react";
 
 export default function FloatingChatbotButton() {
   const router = useRouter();
+  const { data: session } = useSession();
+  const userId = session?.user?.id;
+  const { data: sessions } = useGetRecentChatSessions(userId);
 
   const fullText = "무너에게 물어봐";
   const [visible, setVisible] = useState(true);
   const [typed, setTyped] = useState("");
+  const [showHistory, setShowHistory] = useState(false); // 🔹 최근 세션 보기 상태
 
   useEffect(() => {
     let current = 0;
@@ -25,7 +33,6 @@ export default function FloatingChatbotButton() {
       }
     };
 
-    // 문어 렌더링 이후 살짝 딜레이 후 등장
     const delayStart = setTimeout(() => {
       setVisible(true);
       typeNext();
@@ -38,8 +45,8 @@ export default function FloatingChatbotButton() {
 
   return (
     <div
-      className="fixed bottom-1 left-1/2 z-50 flex translate-x-[calc(220px-100%)] flex-col items-center"
-      onClick={() => router.push("/chat")}>
+      className="fixed bottom-1 left-1/2 z-40 flex translate-x-[calc(220px-100%)] flex-col items-center"
+      onClick={() => setShowHistory((prev) => !prev)}>
       <AnimatePresence>
         {visible && (
           <motion.div
@@ -54,13 +61,51 @@ export default function FloatingChatbotButton() {
         )}
       </AnimatePresence>
 
-      <div className="h-40 w-40">
+      <div className="relative h-40 w-40">
+        {/* 🔼 최근 세션 말풍선 */}
+        <AnimatePresence>
+          {showHistory && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 10 }}
+              transition={{ duration: 0.2 }}
+              className="absolute -top-44 left-1/2 w-72 -translate-x-1/2 rounded-xl bg-white px-4 py-3 text-sm shadow-md ring-1 ring-gray-200">
+              <h2 className="mb-2 font-semibold text-gray-800">최근 대화</h2>
+              <ul className="max-h-40 space-y-1 overflow-y-auto text-gray-700">
+                {sessions?.map((s) => (
+                  <li
+                    key={s.id}
+                    className="rounded-md bg-gray-100 px-3 py-2 text-xs">
+                    {s.summary ||
+                      JSON.parse(s.messages)?.[0]?.content ||
+                      "대화 없음"}
+                  </li>
+                ))}
+              </ul>
+              <button
+                onClick={() => {
+                  setShowHistory(false);
+                  router.push("/chat");
+                }}
+                className="mt-3 w-full rounded-full bg-yellow-300 py-1.5 text-xs font-semibold">
+                새 채팅 시작하기
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
+        {/* 말풍선 클릭 감지 영역 */}
+        {/* <div
+          className="absolute top-0 z-0 h-full w-full bg-blue-400"
+          onClick={() => setShowHistory((prev) => !prev)}
+        /> */}
+        {/* 🔘 무너 캐릭터 */}
         <Canvas camera={{ position: [0, 0, 2.5] }}>
           <ambientLight intensity={0.7} />
           <directionalLight position={[0, 0, 2]} intensity={0.6} />
           <hemisphereLight intensity={0.6} groundColor="white" />
           <CharacterModel
-            onClick={() => router.push("/chatbot")}
+            onClick={() => {}}
             isSpeaking={false}
             isThinking={false}
           />

--- a/src/hooks/useGetRecentChatSessions.ts
+++ b/src/hooks/useGetRecentChatSessions.ts
@@ -9,11 +9,11 @@ export type ChatSession = {
   created_at: string;
 };
 
-export const useRecentChatSessions = (userId?: string) => {
+export const useGetRecentChatSessions = (userId?: string) => {
   return useQuery<ChatSession[]>({
     queryKey: ["chatSessions", userId],
     queryFn: async () => {
-      const res = await client.get(`/api/chat-sessions?userId=${userId}`);
+      const res = await client.get(`chat-session?userId=${userId}`);
       return res.data;
     },
     enabled: !!userId, // userId 없을 때는 호출 안함


### PR DESCRIPTION
## #️⃣연관된 이슈
#184 

## 📝작업 내용

- GET /api/chat-sessions?userId=... API 신규 구현 (최근 5개 챗봇 세션 조회)
- useGetRecentChatSessions React Query 훅 작성
- FloatingChatbotButton 컴포넌트에서 무너 캐릭터 클릭 시 말풍선 형태로 최근 세션 표시
  - 캐릭터 위에 framer-motion을 활용한 애니메이션 말풍선 구현
  - 최근 대화 세션 요약(summary) 혹은 첫 메시지 내용을 리스트로 표시
  - 하단에는 + 버튼으로 새 챗팅 시작 유도
- CharacterModel의 onClick 이벤트가 정상 작동하도록 래퍼 요소 위치 조정

### 스크린샷 
![image](https://github.com/user-attachments/assets/1489b950-4e6c-4b01-94e0-abed7caf6762)


## 💬리뷰 요구사항(선택)
> 말풍선 위치나 스타일이 모바일에서 자연스럽게 보이는지 확인 부탁드립니다.
> FloatingChatbotButton 내 상태관리 및 애니메이션 흐름이 직관적인지 피드백 주시면 감사하겠습니다.
