### PR TITLE
[FEAT] 무한스크롤 기능 개선

### DIFF
--- a/src/app/api/plan/page/route.ts
+++ b/src/app/api/plan/page/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 
 //페이지 크기
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 5;
 
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
@@ -18,11 +18,18 @@ export async function GET(req: NextRequest) {
   const plans = await prisma.plan.findMany({
     where,
     skip: page * size,
-    take: size,
+    take: size + 1,
     orderBy: {
       [sort]: order === "asc" ? "asc" : "desc",
     },
   });
 
-  return NextResponse.json(plans);
+  const hasNext = plans.length > size;
+  const sliced = hasNext ? plans.slice(0, size) : plans;
+
+  if (process.env.NODE_ENV !== "production") {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return NextResponse.json({ data: sliced, hasNext });
 }

--- a/src/app/plan/page.tsx
+++ b/src/app/plan/page.tsx
@@ -8,6 +8,7 @@ import PlanListCard from "@/components/planList/PlanListCard";
 import { useInfinitePlans } from "@/hooks/useInfinitePlans";
 import { getScoreContext } from "@/utils/planScore";
 import PlanListTrigger from "@/components/planList/PlanListTrigger";
+import { PlanDBApiResponse } from "@/types/PlanData";
 
 const getEnumNetworkType = (
   type: UINetworkType | null
@@ -29,14 +30,20 @@ export default function PlanListPage() {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
     useInfinitePlans(sortTarget, sortOrder, selectedNetwork);
 
-  const allPlans = data?.pages.flat() ?? [];
+  const planMap = new Map<number, PlanDBApiResponse>();
+  data?.pages.forEach((page) => {
+    page.data.forEach((plan) => {
+      planMap.set(plan.id, plan);
+    });
+  });
+  const allPlans = Array.from(planMap.values());
   const scoreContext = allPlans.length > 0 ? getScoreContext(allPlans) : null;
 
   useEffect(() => {
-    if (listRef.current) {
-      listRef.current.scrollIntoView({ behavior: "smooth" });
+    if (!data || data.pages.length === 1) {
+      listRef.current?.scrollIntoView({ behavior: "smooth" });
     }
-  }, [data]);
+  }, []);
 
   if (status === "pending" || !scoreContext) {
     return (
@@ -51,33 +58,6 @@ export default function PlanListPage() {
     );
   }
 
-  const mappedNetwork = getEnumNetworkType(selectedNetwork);
-  let filteredPlans = allPlans;
-  if (mappedNetwork) {
-    filteredPlans = filteredPlans.filter(
-      (plan) => plan.networkType === mappedNetwork
-    );
-  }
-
-  const sortedPlans = sortTarget
-    ? [...filteredPlans].sort((a, b) => {
-        if (sortTarget === "subscriptionServices") {
-          const aLen = Array.isArray(a.subscriptionServices)
-            ? a.subscriptionServices.length
-            : 0;
-          const bLen = Array.isArray(b.subscriptionServices)
-            ? b.subscriptionServices.length
-            : 0;
-          return sortOrder === "asc" ? aLen - bLen : bLen - aLen;
-        }
-        const aVal = a[sortTarget] as number | null;
-        const bVal = b[sortTarget] as number | null;
-        return sortOrder === "asc"
-          ? (aVal ?? 0) - (bVal ?? 0)
-          : (bVal ?? 0) - (aVal ?? 0);
-      })
-    : filteredPlans;
-
   return (
     <div className="relative space-y-6 p-4" ref={listRef}>
       <SortFilterPanel
@@ -90,7 +70,7 @@ export default function PlanListPage() {
       />
 
       <div className="space-y-4">
-        {sortedPlans.map((plan) => (
+        {allPlans.map((plan) => (
           <PlanListCard key={plan.id} plan={plan} />
         ))}
       </div>

--- a/src/components/planList/PlanListTrigger.tsx
+++ b/src/components/planList/PlanListTrigger.tsx
@@ -15,19 +15,26 @@ export default function PlanListTrigger({
   isFetchingNextPage,
 }: PlanListTriggerProps) {
   const { ref, inView } = useInView({
-    threshold: 0.5,
+    threshold: 0.1,
   });
+
+  let timeout: NodeJS.Timeout;
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
+      timeout = setTimeout(() => {
+        fetchNextPage();
+      }, 100); //아주 짧은 debounce 느낌
     }
+    return () => clearTimeout(timeout);
   }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
     <div ref={ref} className="flex h-10 w-full items-center justify-center">
       {isFetchingNextPage && (
-        <span className="text-sm text-gray-500">불러오는 중...</span>
+        <span className="animate-pulse text-sm text-gray-500">
+          📦 불러오는 중...
+        </span>
       )}
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #199

## 📝작업 내용

- 페이지당 5개씩 요금제 불러오도록 수정 (PAGE_SIZE = 5)

- /api/plan/page API 응답 구조에 hasNext 포함 (마지막 페이지 여부 판단)

- PlanListTrigger.tsx에 📦 불러오는 중... 로딩 애니메이션 표시 추가 (무한스크롤 기능을 시각적으로 확인하기 위함)

- 중복 페이지 요청 방지 개선

- PlanListTrigger.tsx threshold 감도 낮춤 (0.5 → 0.1) → 중복 호출 감소 (두 페이지씩 호출되던 문제 해결)

- 500ms 지연 추가로 로딩 확인 (NODE_ENV !== "production" 조건)

### 스크린샷

- 무한스크롤 기능: 5개씩 데이터 호출. 호출 시 하단 텍스트 출력. 지연 시간 추가
https://github.com/user-attachments/assets/de54713e-c1e6-40a5-b17d-304445b23ec6

## 💬리뷰 요구사항

> 이번 PR에서는 무한 스크롤에 관한 기능 개선을 작업하였고, 다음 작업으로 컴포넌트 분리와 디자인 개선을 진행할 예정입니다.

> 무한스크롤 기능은 처음 작업해서 테스트하고 피드백 주시면 감사하겠습니다!
