### PR TITLE
[FEAT] home, root와 온보딩 화면 연결 및 신규가입자 확인 API 구현

### DIFF
--- a/src/app/api/auth/is-new-user/route.ts
+++ b/src/app/api/auth/is-new-user/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ isNew: false }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!user?.created_at) {
+    return NextResponse.json({ isNew: false }, { status: 404 });
+  }
+
+  const now = new Date();
+  const createdAt = new Date(user.created_at);
+  const diffInMinutes = (now.getTime() - createdAt.getTime()) / 1000 / 60;
+
+  // 가입한 지 3분 이내면 신규 사용자로 간주
+  const isNew = diffInMinutes < 3;
+
+  return NextResponse.json({ isNew });
+}

--- a/src/app/check-user-type/page.tsx
+++ b/src/app/check-user-type/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function CheckUserTypePage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const check = async () => {
+      const res = await fetch("/api/auth/is-new-user");
+      const data = await res.json();
+      if (data.isNew) {
+        router.replace("/onboarding");
+      } else {
+        router.replace("/home");
+      }
+    };
+
+    check();
+  }, [router]);
+
+  return <p className="mt-20 text-center">로그인 확인 중입니다...</p>;
+}

--- a/src/app/check-user-type/page.tsx
+++ b/src/app/check-user-type/page.tsx
@@ -2,14 +2,15 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { client } from "@/lib/axiosInstance";
 
 export default function CheckUserTypePage() {
   const router = useRouter();
 
   useEffect(() => {
     const check = async () => {
-      const res = await fetch("/api/auth/is-new-user");
-      const data = await res.json();
+      const res = await client.get("/auth/is-new-user");
+      const data = await res.data;
       if (data.isNew) {
         router.replace("/onboarding");
       } else {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -102,11 +102,7 @@ export default function onBoardingPage() {
         direction: "right",
       }));
     } else {
-      if (!session) {
-        signIn("kakao", { callbackUrl });
-      } else {
-        router.push("/home");
-      }
+      router.push("/home");
     }
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,19 +7,26 @@ import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import { signIn, useSession } from "next-auth/react";
 import Image from "next/image";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function Home() {
   const router = useRouter();
   const { data: session, status } = useSession();
-  const pathname = usePathname();
+
+  // 로그인 상태면 홈으로 자동 리다이렉트
+  useEffect(() => {
+    if (status === "authenticated") {
+      router.replace("/home");
+    }
+  }, [status, router]);
 
   const handleLogin = () => {
-    signIn("kakao", { callbackUrl: pathname });
+    signIn("kakao", { callbackUrl: "/check-user-type" });
   };
 
   const handleExplore = () => {
-    session ? router.push("/home") : router.push("/onboarding");
+    router.push("/onboarding");
   };
 
   const tmp = () => {

--- a/src/components/home/HomeHeader.tsx
+++ b/src/components/home/HomeHeader.tsx
@@ -23,7 +23,7 @@ export default function HomeHeader({ onAvatarClick }: Props) {
   );
 
   const handleLogin = () => {
-    signIn("kakao", { callbackUrl });
+    signIn("kakao", { callbackUrl: "/check-user-type" });
   };
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈

#210 

## 📝작업 내용

- 유저가 신규 가입자인지 확인하는 `is-new-user` API 구현 (가입한지 3분 이내라면 신규 가입자로 판단)
- 루트에서 로그인이 끝난 직후 신규 사용자 여부에 따라 분기 처리만 담당하는 중간 리다이렉트 페이지 `check-user-type/page.tsx` 생성
    - 해당 페이지에서 신규가입자일 경우 온보딩으로, 아닐 경우 `/home`으로 이동
- 온보딩 페이지에서 시작하기 누를 경우 로그인 여부 관계 없이 `/home`으로 이동
- 로그인 상태에서 루트(`/`) 페이지 접속시 `/home`으로 자동 리다이렉트 처리

### 스크린샷 (선택)
- 로그인 완료 후 유저가 신규가입자일 경우 온보딩으로 이동
![화면 기록 2025-06-18 오후 7 33 03](https://github.com/user-attachments/assets/071275bc-45e5-45c3-9846-48e97803ddd6)


- 비로그인 상태에서 시작하기 클릭시 `/home`으로 리다이렉트
![화면 기록 2025-06-18 오후 7 26 09](https://github.com/user-attachments/assets/55b905d7-704b-45b3-bdb6-531f7fdeef10)


- 로그인 상태에서 루트(`/`) 페이지 접속시 `/home`으로 자동 리다이렉트 처리
![화면 기록 2025-06-18 오후 7 23 33](https://github.com/user-attachments/assets/ed9f1d84-82b7-4723-bb26-877336b555fe)


## 💬리뷰 요구사항(선택)
- 로그아웃 기능이 따로 없어서 아마 최초로그인 이후 온보딩 화면을 다시 볼 수 없을 듯한데 온보딩을 최초로그인 or 비로그인 외의 다른 경우에도 확인할 수 있는게 좋을 지 의견 부탁드립니당
- 신규가입자 판단 여부를 created_at로 비교해서 가입한지 3분 이내면 신규가입자 처리했습니다 이부분에 대한 의견 있으면 알려주세요
(이 api를 온보딩에만 사용하는 것 같아서 3분으로 임의 지정했습니다)

- 중간 리다이렉트 페이지를 < p >로그인 확인 중입니다...< /p > 로만 처리했는데 ui 구현에 대한 의견 있으시면 피드백주세요 !