### PR TITLE
[FEAT] 마이페이지-공유 카운트 별 도장 애니메이션 추가 + invited_count zustand 추가

### DIFF
--- a/src/components/myPage/MyPageModal.tsx
+++ b/src/components/myPage/MyPageModal.tsx
@@ -18,6 +18,7 @@ import { getScoreContext } from "@/utils/planScore";
 import { PlanDetailData } from "@/types/planDetail";
 import { useSession } from "next-auth/react";
 import TypeLevel from "./TypeLevel";
+import { useUserStore } from "@/store/userStore";
 
 type Props = {
   open: boolean;
@@ -32,7 +33,7 @@ export default function MyPageModal({ open, onOpenChange }: Props) {
   } = useGetAllPlans();
 
   const { data: session } = useSession();
-  const [invitedCount, setInvitedCount] = useState(0);
+  const { setInvitedCount: setInvitedCountZustand } = useUserStore();
   const [selectedPlanId, setSelectedPlanId] = useState("");
   const [userType, setUserType] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -40,7 +41,6 @@ export default function MyPageModal({ open, onOpenChange }: Props) {
     null
   );
 
-  // 모달이 열릴 때 유저의 현재 요금제 및 초대 개수 불러오기
   useEffect(() => {
     if (!open) return;
     if (!session?.user?.id) return;
@@ -51,9 +51,11 @@ export default function MyPageModal({ open, onOpenChange }: Props) {
         const userMyPlanId = res.data.my_plan;
         const userInvitedCount = res.data.invited_count;
         const userType = res.data.type;
+
         if (userMyPlanId) setSelectedPlanId(userMyPlanId.toString());
         else setSelectedPlanId("");
-        setInvitedCount(userInvitedCount ?? 0);
+
+        setInvitedCountZustand(userInvitedCount ?? 0); // zustand 공유 상태
         setUserType(userType ?? null);
       } catch (err) {
         console.error("유저 요금제 정보 불러오기 실패", err);
@@ -106,9 +108,12 @@ export default function MyPageModal({ open, onOpenChange }: Props) {
         <DialogDescription className="sr-only">
           나의 요금제 설정 및 정보를 확인할 수 있는 모달
         </DialogDescription>
-        <UserProfile invitedCount={invitedCount} />
-        <TypeLevel invitedCount={invitedCount} typeName={userType} />
-        <UserStamp invitedCount={invitedCount} />
+        <UserProfile invitedCount={useUserStore.getState().invitedCount} />
+        <TypeLevel
+          invitedCount={useUserStore.getState().invitedCount}
+          typeName={userType}
+        />
+        <UserStamp />
 
         <div className="mt-1 flex items-center justify-between">
           <div className="flex w-full flex-col">

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+type UserState = {
+  invitedCount: number;
+  setInvitedCount: (count: number) => void;
+};
+
+export const useUserStore = create<UserState>((set) => ({
+  invitedCount: 0,
+  setInvitedCount: (count) => set({ invitedCount: count }),
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #221 

## 📝작업 내용

> 마이페이지-공유 카운트 별 도장 애니메이션 추가 + zustand를 사용하여 새로 변한 숫자만큼만 애니메이션 추가
- 모달 첫 구동 시 유저의 invited_count 상태를 저장
- invited_count 변화가 있는 만큼만 애니메이션 작동 (gsap 사용)
- 이미지 scale 렌더링 시 경계선이 생기는 이슈 발생 -> backfaceVisibility: "hidden" 추가하여 해결
![image](https://github.com/user-attachments/assets/9a35f867-cc4f-46d5-9e07-f452f93fc6f1)


### 스크린샷 (선택)
1. 도장이 하나가 이미 있었고, 개수 변경되었을 때 모달 다시 누르면 변경된 도장 개수만큼만 애니메이션 처리
![도장](https://github.com/user-attachments/assets/d82ed18f-485c-49f5-84f7-9af59afdb61e)

2. 추가된 invited_count가 1이 아니고 여러개인 경우 애니메이션
![도장 여러개](https://github.com/user-attachments/assets/28e474f3-1c46-4384-bf90-c512243ce13f)


## 💬리뷰 요구사항(선택)

> 도장 찍히는 애니메이션 길이를 1초로 설정했는데, 너무 느릴까요?
