### PR TITLE
[FEAT] 마이페이지 - 홈 화면에 있던 타입 방사형 그래프 추가

### DIFF
--- a/src/components/home/UserTendencyRadar.tsx
+++ b/src/components/home/UserTendencyRadar.tsx
@@ -31,6 +31,44 @@ export default function UserTendencyRadar() {
 
   const { data, isLoading } = useGetUserCharacterProfile(userId ?? "");
 
+  const iconMap = {
+    SNS: "/assets/moono/sns-moono.png",
+    Youtube: "/assets/moono/youtube-moono.png",
+    Chat: "/assets/moono/chat-moono.png",
+    Calling: "/assets/moono/calling-moono.png",
+    Books: "/assets/moono/books-moono.png",
+    Saving: "/assets/moono/saving-moono.png",
+  };
+
+  const drawIconsPlugin = {
+    id: "drawIconsPlugin",
+    afterDraw: (chart: any) => {
+      const ctx = chart.ctx;
+      const rScale = chart.scales.r;
+      const labels = chart.data.labels;
+
+      type IconLabel = keyof typeof iconMap;
+
+      labels.forEach((label: string, index: number) => {
+        const pos = rScale.getPointPositionForValue(index, rScale.max); // 라벨 위치 기준
+        const img = new Image();
+        img.src = iconMap[label as IconLabel];
+
+        img.onload = () => {
+          const size = 36; // 원하시는 만큼 키우세요
+          const offsetY = -28; // 텍스트 위로 올리기 위한 y축 보정
+          ctx.drawImage(
+            img,
+            pos.x - size / 2,
+            pos.y - size / 2 + offsetY,
+            size,
+            size
+          );
+        };
+      });
+    },
+  };
+
   if (status === "loading" || isLoading) {
     return <div>로딩 중...</div>;
   }
@@ -63,6 +101,7 @@ export default function UserTendencyRadar() {
   };
 
   const radarOptions: ChartOptions<"radar"> = {
+    maintainAspectRatio: false,
     scales: {
       r: {
         beginAtZero: true,
@@ -112,8 +151,12 @@ export default function UserTendencyRadar() {
   };
 
   return (
-    <div className="mx-auto max-w-xl">
-      <Radar data={radarData} options={radarOptions} />
+    <div className="mx-auto h-[300px] w-full max-w-xl">
+      <Radar
+        data={radarData}
+        options={radarOptions}
+        plugins={[drawIconsPlugin]}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #227

## 📝작업 내용

> 홈 화면에 있던 타입 방사형 그래프를 마이페이지 모달 안에 추가하였습니다.
홈 화면 내용은 수정하지 않았습니다~

- 추후 작업 내용
- 전역상태 관리
- 이미지 위치 조정
- 도장 5,10번째 레벨업 디자인으로 수정 + 효과

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/52b7ed7c-7669-4000-9813-261e3713cdf0)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
