### PR TITLE
Feat/216 socket stamp

### DIFF
--- a/src/app/api/user/invite-multiple/route.ts
+++ b/src/app/api/user/invite-multiple/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+// ✅ 근거리 통신에서 stamp를 찍은 count만큼 invited_count를 증가시키는 API
+export async function POST(req: NextRequest) {
+  try {
+    const { inviterId, count } = await req.json();
+
+    if (!inviterId || typeof count !== "number") {
+      return NextResponse.json(
+        { error: "inviterId 또는 count 값이 잘못되었습니다." },
+        { status: 400 }
+      );
+    }
+
+    const updated = await prisma.user.update({
+      where: { id: inviterId },
+      data: {
+        invited_count: {
+          increment: count,
+        },
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      invited_count: updated.invited_count,
+    });
+  } catch (err) {
+    console.error("🔴 초대 수 증가 오류:", err);
+    return NextResponse.json({ error: "서버 오류" }, { status: 500 });
+  }
+}

--- a/src/hooks/useNearbySocket.ts
+++ b/src/hooks/useNearbySocket.ts
@@ -43,7 +43,7 @@ export function useNearbySocket(
       };
 
       sendLocation();
-      intervalId = setInterval(sendLocation, 5000);
+      intervalId = setInterval(sendLocation, 1000);
     };
     socket.onmessage = (event) => {
       try {


### PR DESCRIPTION
## #️⃣연관된 이슈
#216 

## 📝작업 내용
- **특정 사용자 클릭 시 해당 사용자에게 알림 전송**
  - 클릭 정보(보낸 사람 이름 포함)를 WebSocket으로 전송
  - **알림 전송 시 사용자 이름 표시**
     -  `WebSocket` 메시지 내에서 사용자 이름 함께 전송
     - userInfo.name 클라이언트에서 유지

-  **페이지 이탈 시 초대 수(stamp) 반영**
    - `Set`에 저장된 클릭된 사용자 ID를 페이지 이탈 시 `axios`로 서버에 `invited_count` 증가 요청 
    - `Axios` + `beforeunload`보다 크로스 브라우저 신뢰도 높고, SPA 내 네비게이션도 처리 가능한 `window.pagehide` 이벤트
 
  
### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/93ddcbd6-bc3a-4a74-86cc-d16a04cf50fc)
![image](https://github.com/user-attachments/assets/53ec326e-fe38-4ea9-bda1-f9c41c021508)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
