### PR TITLE
[FEAT] 밈테스트 2차 QA 수정

### DIFF
--- a/src/app/meme-test/TestHomePage.tsx
+++ b/src/app/meme-test/TestHomePage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import HamburgerMenu from "@/components/common/HamburgerMenu";
 import HomeHeader from "@/components/home/HomeHeader";
 import ShareSection from "@/components/meme/shareSection";
 import { useAnimatedCount } from "@/hooks/useAnimatedCount";

--- a/src/app/meme-test/TestHomePage.tsx
+++ b/src/app/meme-test/TestHomePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import HamburgerMenu from "@/components/common/HamburgerMenu";
+import HomeHeader from "@/components/home/HomeHeader";
 import ShareSection from "@/components/meme/shareSection";
 import { useAnimatedCount } from "@/hooks/useAnimatedCount";
 import { useGetTypeRankQuery } from "@/hooks/useGetTypeRankQuery";
@@ -34,74 +35,73 @@ export default function TestHomePage() {
   };
 
   return (
-    <div className="flex h-full w-full flex-col bg-pink-200 px-0">
-      <div className="flex justify-between px-3">
-        <img src="/assets/icons/logo.png" alt="logo" className="w-20" />
-        <div className="pt-5">
-          <HamburgerMenu />
-        </div>
-      </div>
-
-      <div className="flex flex-1 flex-col items-center justify-center">
-        <img
-          src="/assets/icons/meme-test-home.png"
-          alt="home"
-          className="w-[90%]"
-        />
-
-        <button
-          onClick={handleStart}
-          className="mb-5 w-[40%] cursor-pointer rounded-lg bg-pink-400 px-6 py-2 text-lg font-semibold text-white shadow-md transition hover:bg-yellow-500">
-          시작하기
-        </button>
-
-        <div className="text-center">
-          <p className="mb-2 text-xl font-bold text-black">
-            <span className="relative z-10 inline-block">
-              <span
-                className="absolute bottom-[0.3em] left-0 -z-10 h-[0.26em] w-full bg-yellow-500"
-                aria-hidden="true"
-              />
-              참여자 수
-            </span>
-          </p>
-          <p className="text-2xl font-bold text-black">
-            {animatedCount.toLocaleString("ko-KR")}
-          </p>
+    <div className="flex h-full flex-col items-center bg-pink-200">
+      <section className="z-1 flex h-[85%] w-[90%] flex-col items-center">
+        <div className="flex w-full items-center justify-between">
+          <HomeHeader />
         </div>
 
-        <hr className="my-5 w-[90%] border border-pink-400" />
+        <div className="flex flex-1 flex-col items-center justify-center">
+          <img
+            src="/assets/icons/meme-test-home.png"
+            alt="home"
+            className="w-[90%]"
+          />
 
-        <ShareSection
-          title="테스트 공유하기"
-          count={data.sharedCount ?? 0}
-          id={session?.user.id ?? 0}
-          shareUrl="/meme-test"
-        />
+          <button
+            onClick={handleStart}
+            className="mb-5 w-[40%] cursor-pointer rounded-lg bg-pink-400 px-6 py-2 text-lg font-semibold text-white shadow-md transition hover:bg-yellow-500">
+            시작하기
+          </button>
 
-        <div className="mb-8 flex w-[90%] flex-col gap-4 rounded-lg border-1 border-pink-400 bg-white p-4 shadow-md">
-          {topMoonos.map((moono, index) => (
-            <div key={index} className="flex w-full">
-              <div className="ml-10 flex w-1/2 items-center justify-start">
-                <div className="mr-5 h-7 w-1 bg-pink-400"></div>
-                <span className="mr-10 text-sm font-bold text-black">
-                  {index + 1}등
-                </span>
-                <img
-                  src={`/assets/moono/${moono.image}.png`}
-                  alt={moono.label}
-                  className="ml-3 h-12 w-12"
+          <div className="text-center">
+            <p className="mb-2 text-xl font-bold text-black">
+              <span className="relative z-10 inline-block">
+                <span
+                  className="absolute bottom-[0.3em] left-0 -z-10 h-[0.26em] w-full bg-yellow-500"
+                  aria-hidden="true"
                 />
+                참여자 수
+              </span>
+            </p>
+            <p className="text-2xl font-bold text-black">
+              {animatedCount.toLocaleString("ko-KR")}
+            </p>
+          </div>
+
+          <hr className="my-5 w-[90%] border border-pink-400" />
+
+          <ShareSection
+            title="테스트 공유하기"
+            count={data.sharedCount ?? 0}
+            id={session?.user.id ?? 0}
+            shareUrl="/meme-test"
+          />
+
+          <div className="mb-8 flex w-[90%] flex-col gap-4 rounded-lg border-1 border-pink-400 bg-white p-4 shadow-md">
+            {topMoonos.map((moono, index) => (
+              <div key={index} className="flex w-full">
+                <div className="ml-10 flex w-1/2 items-center justify-start">
+                  <div className="mr-5 h-7 w-1 bg-pink-400"></div>
+                  <span className="mr-5 text-sm font-bold whitespace-nowrap text-black">
+                    {index + 1}등
+                  </span>
+                  <img
+                    src={`/assets/moono/${moono.image}.png`}
+                    alt={moono.label}
+                    className="ml-3 h-12 w-12"
+                  />
+                </div>
+                <div className="flex w-1/2 items-center justify-center pr-3">
+                  <p className="text-sm font-semibold text-black">
+                    {moono.label}
+                  </p>
+                </div>
               </div>
-              <div className="flex w-1/2 items-center justify-center pr-3">
-                <p className="text-sm font-semibold text-black">
-                  {moono.label}
-                </p>
-              </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/app/meme-test/result/[id]/resultPage.tsx
+++ b/src/app/meme-test/result/[id]/resultPage.tsx
@@ -83,7 +83,7 @@ export default function ResultPage({ encryptedId }: { encryptedId: string }) {
     router.push("/meme-test");
   };
   const handleOpenHomeInNewTab = () => {
-    window.open("/", "_blank");
+    window.open("/chat", "_blank");
   };
   const handleNavigateToRankPage = () => {
     router.push("/meme-test/rank");
@@ -180,8 +180,10 @@ export default function ResultPage({ encryptedId }: { encryptedId: string }) {
           </div>
           <div className="flex w-[90%] flex-col gap-4">
             <p className="text-[11px] text-black">
-              본 테스트는 LG유플러스와의 협업을 통해 제작되었으며, <br />
-              테스트 결과에 기반한 추천 요금제는 모두 LG유플러스의 요금제입니다.
+              본 테스트의 요금제 추천 결과는 모두 LG유플러스 요금제를 기준으로
+              제공됩니다.
+              <br />
+              [자료 출처: 스마트초이스]
             </p>
           </div>
         </div>

--- a/src/app/meme-test/result/[id]/resultPage.tsx
+++ b/src/app/meme-test/result/[id]/resultPage.tsx
@@ -126,7 +126,7 @@ export default function ResultPage({ encryptedId }: { encryptedId: string }) {
                 </span>
               ))}
             </div>
-            <div className="mt-3 flex flex-col text-[11px] leading-relaxed">
+            <div className="mt-3 flex flex-col text-[12px] leading-relaxed">
               {splitSentences.map((line, idx) => (
                 <p key={idx} className="mb-[3px]">
                   {renderHighlightedText(line)}
@@ -179,7 +179,7 @@ export default function ResultPage({ encryptedId }: { encryptedId: string }) {
             )}
           </div>
           <div className="flex w-[90%] flex-col gap-4">
-            <p className="text-[11px] text-black">
+            <p className="text-[11px] text-gray-800">
               본 테스트의 요금제 추천 결과는 모두 LG유플러스 요금제를 기준으로
               제공됩니다.
               <br />
@@ -246,7 +246,7 @@ export default function ResultPage({ encryptedId }: { encryptedId: string }) {
           <div className="mt-4 flex w-[90%] flex-col items-center justify-between">
             <ShareSection
               title="내 결과 공유하기"
-              count={data?.sharedCount || 0}
+              count={user.invited_count || 0}
               id={decryptedId}
               shareUrl={`/meme-test/result/${encryptedId}`}
             />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #266 

## 📝작업 내용

- 결과 페이지 中 무너에게 물어봐 하단 버튼 연결 -> moomool - chat으로 연결
- 메인페이지 1등, 2등 문구 위치 수정 (레이아웃)
- 테스트 공유하기 카운트(결과화면) 전체 카운팅->개별카운팅으로 변경
- sns 보너스 문항 범위조절
- 메인페이지에서 무물 클릭 시 /home 이동


### 스크린샷 (선택)
메인화면 등수 줄바뀜 수정
![image](https://github.com/user-attachments/assets/78713715-9bc4-4d34-987c-b385f5762cb7)

유플러스 요금제 사용(스마트초이스 출처 표기)
![image](https://github.com/user-attachments/assets/fa83bef4-c029-4349-bba2-898b323f20f4)

개별 카운트로 변경
![image](https://github.com/user-attachments/assets/95d76164-38f7-45ce-8df5-b594015a7159)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
