### PR TITLE
[FEAT] 챗봇 voice ↔ text 모드 전환 및 헤더 흐름 수정

### DIFF
--- a/src/components/chat/ChatbotHeader.tsx
+++ b/src/components/chat/ChatbotHeader.tsx
@@ -75,7 +75,7 @@ export default function Header({ title = "챗봇", onAvatarClick }: HeaderProps)
   return (
     <div className="relative flex h-12 items-center justify-center bg-white">
       <Button className="absolute left-2" variant="ghost" onClick={handleClick}>
-        {isVoiceMode ? <ArrowLeft size={20} /> : <X size={20} />}
+        <X size={20} />
       </Button>
       <div className="text-center text-sm font-semibold">{title}</div>
       <div className="absolute right-4">

--- a/src/components/chat/ChatbotHeader.tsx
+++ b/src/components/chat/ChatbotHeader.tsx
@@ -9,7 +9,6 @@ import { usePostChatbotSummary } from "@/hooks/usePostChatbotSummary";
 import { useSession } from "next-auth/react";
 import { useFreeTalkStore } from "@/store/useFreeTalkStore";
 import { useTendencyStore } from "@/store/useTendencyStore";
-import { useChatModeStore } from "@/store/useChatModeStore";
 
 type HeaderProps = {
   title: string;
@@ -17,8 +16,6 @@ type HeaderProps = {
 
 export default function Header({ title = "챗봇" }: HeaderProps) {
   const router = useRouter();
-  const { mode, setMode } = useChatModeStore();
-  const isVoiceMode = mode === "voice";
 
   const { data: session } = useSession(); // 로그인 정보 가져오기
   const { messages } = useChatStore();
@@ -34,40 +31,36 @@ export default function Header({ title = "챗봇" }: HeaderProps) {
   const { mutate: chatHistorySummary } = usePostChatbotSummary();
 
   const handleClick = async () => {
-    if (isVoiceMode) {
-      setMode("text");
-    } else {
-      if (currentQuestionId === 12 && hasRecommended) {
-        if (!session?.user?.id) return;
+    if (currentQuestionId === 12 && hasRecommended) {
+      if (!session?.user?.id) return;
 
-        const currentMessages = useChatStore.getState().messages;
-        const lastBotMsg = currentMessages
-          .reverse()
-          .find((m) => m.role === "bot");
-        const planId = lastBotMsg?.planData?.id ?? 5;
+      const currentMessages = useChatStore.getState().messages;
+      const lastBotMsg = currentMessages
+        .reverse()
+        .find((m) => m.role === "bot");
+      const planId = lastBotMsg?.planData?.id ?? 5;
 
-        try {
-          // 모든 작업 순차적으로 수행
-          await chatHistorySummary({
-            userId: session.user.id,
-            messages,
-            planId,
-          });
-          setCurrentQuestionId(0);
-          setHasRecommended(false);
-          clearMessages();
-          clear();
-          resetTendency();
+      try {
+        // 모든 작업 순차적으로 수행
+        await chatHistorySummary({
+          userId: session.user.id,
+          messages,
+          planId,
+        });
+        setCurrentQuestionId(0);
+        setHasRecommended(false);
+        clearMessages();
+        clear();
+        resetTendency();
 
-          // 모든 작업 후에 뒤로가기
-          router.back();
-        } catch (error) {
-          console.error("chatHistorySummary 실패:", error);
-        }
-      } else {
-        // 조건을 만족하지 않는 경우엔 그냥 뒤로 가기
+        // 모든 작업 후에 뒤로가기
         router.back();
+      } catch (error) {
+        console.error("chatHistorySummary 실패:", error);
       }
+    } else {
+      // 조건을 만족하지 않는 경우엔 그냥 뒤로 가기
+      router.back();
     }
   };
 

--- a/src/components/chat/VoiceFooter.tsx
+++ b/src/components/chat/VoiceFooter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Mic } from "lucide-react";
+import { Mic, X } from "lucide-react";
 import { useVoiceRecorder } from "@/hooks/useVoiceRecorder";
 import ShadowRing from "./ShadowRing";
 import { useHandleAnswer } from "@/hooks/useHandleAnswer";
@@ -11,6 +11,7 @@ import { useBotResponseGuard } from "@/hooks/useBotResponseGuard";
 import { useVoiceControlStore } from "@/store/useVoiceControlStore";
 import { useChatStore } from "@/store/useChatStore";
 import { handleFreeTalkAnswer } from "@/lib/chat/handleFreeTalkAnswer";
+import { useChatModeStore } from "@/store/useChatModeStore";
 
 export default function VoiceFooter() {
   const { recording, result, toggleRecording } = useVoiceRecorder();
@@ -20,6 +21,7 @@ export default function VoiceFooter() {
   const { setWaitingForBotResponse } = useVoiceControlStore();
   const isSpeaking = useTTSStore((state) => state.isSpeaking);
   const [waitingTrigger, setWaitingTrigger] = useState(false);
+  const { setMode } = useChatModeStore();
   useBotResponseGuard(waitingTrigger);
 
   // 음성 인식 결과가 나올 때 자동으로 handleAnswer 실행 (자연스러운 대화 흐름일 경우엔 callGPTFreeTalk 호출)
@@ -54,16 +56,24 @@ export default function VoiceFooter() {
         offsetBottom="3.2rem"
       />
 
-      {/*  마이크 버튼 */}
-      <Button
-        onClick={toggleRecording}
-        disabled={isSpeaking}
-        className="z-10 flex h-16 w-16 items-center justify-center rounded-full bg-yellow-100 shadow-md">
-        <Mic
-          size={30}
-          className={`text-gray-700 ${recording ? "animate-ping" : ""}`}
-        />
-      </Button>
+      {/*  마이크 + X 버튼 */}
+      <div className="z-10 flex flex-row items-center gap-4">
+        <Button
+          onClick={toggleRecording}
+          disabled={isSpeaking}
+          className="z-10 flex h-16 w-16 items-center justify-center rounded-full bg-yellow-100 shadow-md">
+          <Mic
+            size={30}
+            className={`text-gray-700 ${recording ? "animate-ping" : ""}`}
+          />
+        </Button>
+        <Button
+          onClick={() => setMode("text")}
+          variant="ghost"
+          className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-100 shadow-md">
+          <X size={28} className="text-gray-700" />
+        </Button>
+      </div>
 
       {/*  인식된 텍스트 출력 */}
       {result && (


### PR DESCRIPTION
## #️⃣연관된 이슈
#254 

## 📝작업 내용

- 음성, 텍스트 챗봇 헤더 좌측 아이콘 X로 통일 및 좌측 X 클릭시 `router.back()`
- 음성 모드 마이크 우측에 X 버튼 추가하여 해당 아이콘 클릭시 텍스트로 모드 변경

## 📸 스크린샷
flow) **text 챗봇** → input box의 마이크: **voice 챗봇** → 햄버거바: **요금제 리스트** → 햄버거바: **챗봇** → 마이크 우측 X 버튼: **text 챗봇**→ input box의 마이크: **voice 챗봇** → header 좌측 X: router.back()으로 **요금제 리스트**
<br>

![화면 기록 2025-06-22 오후 4 22 45](https://github.com/user-attachments/assets/16a2ede4-0ef1-44ba-8abf-18886a711bc0)


## 💬리뷰 요구사항(선택)

chatgpt ui와 유사하게 마이크와 동일 크기의 x버튼 생성했으며 디자인은 무난하게 white로 했습니다 피드백 환영~