### PR TITLE
[FEAT] 차트 중앙 애니메이션 추가 개선

### DIFF
--- a/src/components/planDetail/FlipCardChart.tsx
+++ b/src/components/planDetail/FlipCardChart.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { motion } from "framer-motion";
+import { useState, useRef } from "react";
 import TendencyRadarChart from "@/components/chart/PlanDetailRadarChart";
 import TendencyBarChart from "@/components/chart/PlanDetailBarChart";
+import { useInView, motion } from "framer-motion";
 
 interface FlipCardChartProps {
   radar: number[] | number[][];
@@ -23,50 +23,51 @@ export default function FlipCardChart({
   const [flipped, setFlipped] = useState(false);
   const isCompare = mode === "compare";
 
-  const radarData: number[] | [number[], number[]] = Array.isArray(radar[0])
+  const ref = useRef(null);
+  const isInView = useInView(ref, {
+    margin: "-50% 0px -50% 0px", //중앙 기준 감지
+    once: true,
+  });
+
+  const radarData = Array.isArray(radar[0])
     ? (radar as [number[], number[]])
     : (radar as number[]);
-
-  const barData: number[] | [number[], number[]] = Array.isArray(bar[0])
+  const barData = Array.isArray(bar[0])
     ? (bar as [number[], number[]])
     : (bar as number[]);
-
-  const rawData: number[] | [number[], number[]] = Array.isArray(raw[0])
+  const rawData = Array.isArray(raw[0])
     ? (raw as [number[], number[]])
     : (raw as number[]);
 
   return (
     <motion.div
-      className="ml-[-1rem] h-80 w-full max-w-[360px] cursor-pointer"
+      ref={ref}
+      className="ml-[-1rem] h-[20rem] w-full max-w-[22.5rem] cursor-pointer"
       style={{ perspective: "1000px" }}
       onClick={() => setFlipped(!flipped)}
-      initial={{ y: 0 }}
-      whileInView={{ y: [-4, 4, -2, 2, 0] }}
-      transition={{ duration: 0.6 }}
-      viewport={{ once: true, amount: 0.5 }}
-    >
+      animate={
+        isInView ? { rotateY: [0, 60, -50, 30, -20, 0] } : { rotateY: 0 }
+      }
+      transition={{
+        duration: 1.2,
+        ease: "easeInOut",
+      }}>
       <motion.div
         className="relative h-full w-full transition-transform duration-300"
         style={{ transformStyle: "preserve-3d" }}
         animate={{ rotateY: flipped ? 180 : 0 }}
-        transition={{ duration: 0.2 }}
-      >
-        {/* 앞면: 레이더 차트 */}
+        transition={{ duration: 0.2 }}>
         <div
           className="absolute h-full w-full"
-          style={{ backfaceVisibility: "hidden" }}
-        >
+          style={{ backfaceVisibility: "hidden" }}>
           <TendencyRadarChart isRounded={true} data={radarData} name={name} />
         </div>
-
-        {/* 뒷면: 바 차트 */}
         <div
           className="absolute h-full w-full"
           style={{
             transform: "rotateY(180deg)",
             backfaceVisibility: "hidden",
-          }}
-        >
+          }}>
           <TendencyBarChart data={barData} rawData={rawData} name={name} />
         </div>
       </motion.div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #288 

## 📝작업 내용

- useInView과 ref를 활용하여 카드가 페이지 중앙에 들어올 때만 애니메이션 작동
- rotateY 애니메이션을 **[0, 60, -50, 30, -20, 0]**으로 구성하여 일시적 플립 효과 유도 (이걸로 애니메이션 강도 조절)
- 클릭 시에는 기존처럼 180도 회전하며 플립 앞/뒤 전환 유지

### 스크린샷

https://github.com/user-attachments/assets/0feff93a-4d74-43bf-9a8f-d1d6f554a280

- 요금제 리스트 페이지에서 카드는 정상적으로 데이터를 받아오고, 홈 화면에서는 혜택가치 부분을 제거한 것으로 확인되어 그대로 진행하는 게 좋을 것 같습니다.
![image](https://github.com/user-attachments/assets/61341754-7cb3-4b5d-ba35-a8b04940e67c)

## 💬리뷰 요구사항

> rotateY 기반의 플립 애니메이션은 앞·뒷면을 동일한 위치에 겹쳐놓고 회전해야 자연스럽게 전환되므로, absolute로 두 면을 겹쳐야만 정상 작동합니다. absolute가 없으면 두 면이 위아래로 쌓여 시각적으로 전환되지 않고 각각 보이게 됩니다. (결론적으로 absolute를 사용해야만 했습니다.)
