### PR TITLE
[FIX] home에서 nearby toast 안보이는 문제 해결

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Metadata } from "next";
 import Providers from "./providers";
 import Script from "next/script";
 import ClientLayout from "@/components/common/ClientLayout";
+import { Toaster } from "sonner";
 
 export const metadata: Metadata = {
   title: "무물",
@@ -36,11 +37,11 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-
   return (
     <html lang="ko" className="h-full">
       <body className="m-0 h-full bg-gray-500 p-0">
         <Providers>
+          <Toaster position="top-center" richColors />
           <ClientLayout>{children}</ClientLayout>
         </Providers>
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#284 #282 

## 📝작업 내용
global layout에서 toast 내용 빠진 부분 추가하여 다시 home에서 toast 알림뜨게 해결

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/378167b3-89af-4283-9999-706fef1273d4)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
