### PR TITLE
[FIX] 챗봇 채팅 내역에 요금제 카드 저장 안되는 이슈 수정

### DIFF
--- a/src/components/home/ChatHistoryList.tsx
+++ b/src/components/home/ChatHistoryList.tsx
@@ -116,9 +116,7 @@ export default function ChatHistoryList() {
                     )}>
                     <ChatSessionCard
                       id={s.id}
-                      summary={
-                        s.summary || JSON.parse(s.messages)?.[0]?.content
-                      }
+                      summary={s.summary || "요약 내용 없음"}
                       name={s.name}
                     />
                   </CarouselItem>

--- a/src/hooks/usePostChatbotSummary.ts
+++ b/src/hooks/usePostChatbotSummary.ts
@@ -1,22 +1,18 @@
 import { useMutation } from "@tanstack/react-query";
 import { client } from "@/lib/axiosInstance";
 import { Message } from "@/types/Chat";
-import { usePostChatSession } from "./usePostChatSession";
 import { useChatStore } from "@/store/useChatStore";
 
 type ChatbotSummaryInput = {
-  userId: string;
   messages: Message[]; // 자유 형식
-  planId: number;
 };
 
 // 채팅 다 끝내고, 추천까지 받았을 때, 해당 Hook을 사용해 요약 진행
 export const usePostChatbotSummary = () => {
-  const { mutate: submitChatSummary } = usePostChatSession();
   const { setChatSummary } = useChatStore();
 
   return useMutation({
-    mutationFn: async ({ messages, userId, planId }: ChatbotSummaryInput) => {
+    mutationFn: async ({ messages }: ChatbotSummaryInput) => {
       const res = await client.post(
         "/chat-summary",
         {
@@ -31,16 +27,6 @@ export const usePostChatbotSummary = () => {
 
       const summary = res.data.normalizedValue;
       setChatSummary(summary); // chatStore의 summary 내용을 업데이트 (요약을 요금제 추천 카드 뜨기 전에 하기 위함)
-
-      submitChatSummary({ userId, messages, summary, planId });
-
-      return { planId, summary };
-    },
-    onSuccess: (data) => {
-      console.log("채팅 요약 및 저장 성공: ", data.planId, data.summary);
-    },
-    onError: (error) => {
-      console.error("채팅 요약 실패: ", error);
     },
   });
 };

--- a/src/hooks/useSmartChoiceRecommendation.ts
+++ b/src/hooks/useSmartChoiceRecommendation.ts
@@ -1,26 +1,29 @@
 import { useMutation } from "@tanstack/react-query";
 import { client } from "@/lib/axiosInstance";
 import { SmartChoiceApiInput } from "@/types/smartChoiceApiInput";
-import { parsePlans, PlanApiResponse } from "@/types/Chat";
+import { parsePlans } from "@/types/Chat";
 import { useGetFinalPlanInChatbot } from "./useGetFinalPlanInChatbot";
 import { useChatStore } from "@/store/useChatStore";
 import { useTendencyStore } from "@/store/useTendencyStore";
+import { usePostChatbotSummary } from "./usePostChatbotSummary";
 
 // 스마트 초이스에서 응답을 받아오는 useSmartChoiceRecommendation
 export function useSmartChoiceRecommendation() {
   const { userTendencyInfo } = useTendencyStore();
-  const { setRecommendedPlanId } = useChatStore();
+  const { setRecommendedPlanId, setHasRecommended } = useChatStore();
   const addMessage = useChatStore((state) => state.appendMessage);
+  const { mutate: chatHistorySummaryAsync } = usePostChatbotSummary();
 
   // 구독 서비스까지 포함해서 추천을 수행
-  const { mutateAsync: getFinalPlanInChatbot } = useGetFinalPlanInChatbot();
+  const { mutateAsync: getFinalPlanInChatbotAsync } =
+    useGetFinalPlanInChatbot();
 
   return useMutation({
     mutationFn: async (input: SmartChoiceApiInput) => {
       const res = await client.post("/smartchoice", input); // smart choice 호출
       const parsed = parsePlans(res.data);
 
-      const planData = await getFinalPlanInChatbot({
+      const planData = await getFinalPlanInChatbotAsync({
         // subscribe(구독) 정보까지 고려해서 DB를 통해 요금제 정보를 찾아온다
         smartChoicePlans: parsed,
         subscribe: userTendencyInfo.subscribe,
@@ -36,11 +39,21 @@ export function useSmartChoiceRecommendation() {
         planData,
       });
 
-      return planData.id; // mutation이 planId를 반환하게 함
+      return { messages: useChatStore.getState().messages }; // mutation이 planId를 반환하게 함
     },
     retry: 3, // 최대 3회까지 재시도
-    onSuccess: () => {
-      console.log("추천 과정 모두 성공");
+    onSuccess: async ({ messages }) => {
+      try {
+        await chatHistorySummaryAsync({
+          // 얘가 끝날 때까지 기다림
+          messages, // 최신 messages를 바로 전달
+        });
+
+        setHasRecommended(true); // 요약 저장 후 실행됨
+        console.log("추천 및 요약 저장 완료!");
+      } catch (err) {
+        console.error("요약 저장 실패:", err);
+      }
     },
     onError: (error) => {
       // 실패했을 경우 로직


### PR DESCRIPTION
## #️⃣연관된 이슈
#252 

## 📝작업 내용
- 챗봇과의 대화 종료 시, 요금제 카드 저장이 DB에 안되는 오류 수정 (DB에 저장되는 타이밍 조정)
- 관련한 Hook 수정 (`useWatchRecommendationTrigger`, `useSmartChoiceRecommendation`, `usePostChatbotSummary`)

### 스크린샷
<img width="426" alt="스크린샷 2025-06-23 16 49 17" src="https://github.com/user-attachments/assets/c66cd24f-b693-4b17-81cf-c55969d8ea5d" />


## 💬리뷰 요구사항(선택)
- 채팅 요약을 진행하는 로직(`usePostChatbotSummary`)와, 실제 DB에 저장하는 로직을 분리(`useWatchRecommendationTrigger` 내부에서 조건을 만족할 때만 DB에 저장하도록 함)하여 타이밍 문제를 해결했습니다. 해당 로직을 생각하는 데에 생각보다 시간이 오래 걸렸습니다, 죄송합니다 ㅜㅜ 해당 로직이 충분히 효율적일지 분석해 주시면 감사하겠습니다!
