### PR TITLE
[FEAT] 요금제 이름 truncate 적용

### DIFF
--- a/src/components/planDetail/PlanInfo.tsx
+++ b/src/components/planDetail/PlanInfo.tsx
@@ -19,9 +19,13 @@ export default function PlanInfo({
 }: PlanInfoProps) {
   return (
     <div className="px-8">
-      <h1 className="pt-5 text-[1.75rem] leading-snug font-bold [word-break:keep-all] text-gray-900">
-        {data.name}
-      </h1>
+      <div className="scrollbar-hide w-full overflow-x-auto whitespace-nowrap">
+        <h1
+          className="inline-block max-w-full truncate pt-5 text-[1.75rem] leading-snug font-bold [word-break:keep-all] text-gray-900"
+          title={data.name}>
+          {data.name}
+        </h1>
+      </div>
       <p className="text-[1rem] font-semibold text-gray-900">{data.price}</p>
 
       <div className="my-1 mb-5 flex flex-wrap gap-1">

--- a/src/components/planList/PlanListCard.tsx
+++ b/src/components/planList/PlanListCard.tsx
@@ -40,7 +40,11 @@ export default function PlanListCard({
           월 {price.toLocaleString()}원
         </span>
       </div>
-      <div className="text-lg font-bold">{name}</div>
+      <div
+        className="max-w-full truncate overflow-hidden text-lg font-bold whitespace-nowrap"
+        title={name}>
+        {name}
+      </div>
 
       <div className="scrollbar-hide mt-2 flex w-full flex-nowrap gap-2 overflow-x-auto">
         <Badge className="border-0 bg-[#EEF2FF] whitespace-nowrap text-[#4F46E5]">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #313 

## 📝작업 내용

> 상세 페이지의 요금제 이름과 요금제 카드의 요금제 이름에 truncate 적용해서 기존의 개행은 없애서 줄바꿈 없이 긴 이름은 ...으로 표기됩니다.


### 스크린샷

- 상세 페이지
![image](https://github.com/user-attachments/assets/07ae7b50-ee92-46db-9895-bdc81cafc951)

- 요금제 카드
![image](https://github.com/user-attachments/assets/9f0307d1-33c4-4cba-a330-166a1512dca3)
